### PR TITLE
Re-creates #34: add meetings link to readme, slightly tidy meetings

### DIFF
--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,19 +1,23 @@
 # GitOps Working Group Meetings
-Please find meetings of the GitOps Working Group available below. The next meeting will be listed at the top of the list with links to recordings of past meetings available below (when possible). Times listed are GMT.
+The GitOps Working Group meets publicly and anyone interested is welcome to attend.
+
+A regular cadence schedule is in development. For now, the next meeting will be posted here, with links to minutes of past meetings and recordings when possible. Times listed are GMT.
 
 ## Upcoming Meetings
 Thursday, February 11th at 18:00 GMT
 [Video Conference Link](https://weaveworks.zoom.us/j/93181235360)<br>
 Meeting ID: 93181235360
-<br><br><br>
+<br><br>
 
 ## Past Meetings
 Thursday, January 14th at 17:00 GMT
 [Video Recording](https://weaveworks.zoom.us/rec/share/_qrMRze16IHb2d4KIOHSa2Wxb_XzbU41-ZH6YZI5aJkUqOHM1bBQLCQhkFva5xo0.ay0LdxTVPCTlgbSd)<br>
-Passcode: EpQ26^cV<br>
-[Meeting Notes:](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+Passcode: EpQ26^cV
 
 Thursday, December 10th at 17:00 GMT
 [Video Recording](https://weaveworks.zoom.us/rec/share/jyagKQsL7irvi1pF-RHzrrwH-Sqa59wNnBK0F2H8QYBo_rxJZOXMO-5j5CwUgKiK.9cl0var5BN-z0qrI)<br>
-Passcode: %mi$&f8e<br>
-[Meeting Notes:](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+Passcode: %mi$&f8e
+<br><br>
+
+## Meeting Notes
+Rolling meeting notes are available [here](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The founders of the GitOps Working Group envision the creation of a GitOps Manif
 With the announcement of the GitOps Working Group the founders would like to invite other companies to join the group and contribute to the community and the adoption of GitOps across the cloud native landscape. There are a few ways you can get involved:
 
 - Watch or star this repo to see when things change.
-- Attend a working group meeting (schedule coming soon).
+- Attend a [Working Group meeting](./MEETINGS.md) (schedule coming soon).
 - [Open an issue](/../../issues/new) and let us know how you're using GitOps and any important considerations we should include.
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
 


### PR DESCRIPTION
Re-creates https://github.com/gitops-working-group/gitops-working-group/pull/34 from https://github.com/jlbutler/gitops-working-group/commit/dcdec38c7d9c32d72e2823ab9129fdf1e4904850

See #37 