### PR TITLE
Define the GitOps Principles

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -6,7 +6,7 @@
 
 - **State Store**
     
-    A system for storing versioned, immutable Desired States that provides access control and auditing on the changes to the Desired State. Git may be configured as a State Store, but special precautions must be taken.
+    A system for storing versioned, immutable Desired States that provides access control and auditing on the changes to the Desired State. Git may be configured as a State Store, but [special precautions must be taken](recipes/SETTING_UP_GIT.md).
 
 - **Reconciliation**
   

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,21 @@
+# Glossary
+
+- **Desired state**
+
+    The aggregate of all configuration data for a system form its "Desired State". The "Desired State" of a system is defined as data sufficient to recreate the system from nothing so that instances of the system are behaviorally indinstinguishable.
+
+- **State Store**
+    
+    A system for storing versioned, immutable Desired States that provides access control and auditing on the chnages to the Desired State. Git may be configured as a State Store, but special precautions must be taken.
+
+- **Reconciliation**
+  
+  A continuously running attempt to reconcile _Definition_ of desired state with the current state.
+
+- **Software System**
+
+    One or more Runtime environments consisting of resources under management
+    In each Runtime, management Agents to act on resources according to security policies.
+    One or more software Repositories for storing deployable artifacts that may be loaded into the runtime environments, eg. configuration files, code, binaries and packages. 
+    One or more Administrators who are responsible for operating the runtime environments ie. installing, starting, stopping and updating software, code, configuration, etc.
+    A set of policies controlling access and management of repos, deployment, runtimes.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,21 +1,21 @@
 # Glossary
 
-- **Desired state**
+- **Desired State**
 
-    The aggregate of all configuration data for a system form its "Desired State". The "Desired State" of a system is defined as data sufficient to recreate the system from nothing so that instances of the system are behaviorally indinstinguishable.
+    The aggregate of all configuration data for a system form its "Desired State".  The "Desired State" of a system is defined as data sufficient to recreate the system so that instances of the system are behaviourally indistinguishable.
 
 - **State Store**
     
-    A system for storing versioned, immutable Desired States that provides access control and auditing on the chnages to the Desired State. Git may be configured as a State Store, but special precautions must be taken.
+    A system for storing versioned, immutable Desired States that provides access control and auditing on the changes to the Desired State. Git may be configured as a State Store, but special precautions must be taken.
 
 - **Reconciliation**
   
-  A continuously running attempt to reconcile _Definition_ of desired state with the current state.
+  The process by which the current state of a system is compared against and made consistent with the system's desired state as declared in the state store
 
 - **Software System**
 
-    One or more Runtime environments consisting of resources under management
+    One or more Runtime environments consisting of resources under management.
     In each Runtime, management Agents to act on resources according to security policies.
     One or more software Repositories for storing deployable artifacts that may be loaded into the runtime environments, eg. configuration files, code, binaries and packages. 
     One or more Administrators who are responsible for operating the runtime environments ie. installing, starting, stopping and updating software, code, configuration, etc.
-    A set of policies controlling access and management of repos, deployment, runtimes.
+    A set of policies controlling access and management of repositories, deployments, runtimes.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -37,8 +37,7 @@ GitOps principles were derived from modern software operations but are rooted in
 
 1. [**The principle of declarative configuration**](#1-declarative-configuration)
 
-    A system managed by GitOps must have its _Desired State_ expressed declaritively as data.
-    This declarative data must be in a format writable and readable by both humans and software.
+    A system managed by GitOps must have its _Desired State_ expressed declaritively as data in a format writable and readable by both humans and machines.
 
 2. [**The principle of immutable configuration versions**](#2-immutable-configuration-versions)
 
@@ -82,8 +81,7 @@ The GitOps principles are a direction, not a destination. They should be applied
 ### 1. Declarative configuration
 
 <div style="background: #E3F2FD; border-left: 3px solid #0D47A1; padding:10px; margin-bottom:5px; font-style:italic">
-A system managed by GitOps must have its <em>Desired State</em> expressed declaritively as data.
-This declarative data must be in a format writable and readable by both humans and software.
+A system managed by GitOps must have its _Desired State_ expressed declaritively as data in a format writable and readable by both humans and machines.
 </div>
 
 #### What is a system's Desired State?

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -90,7 +90,6 @@ A system managed by GitOps must have its _Desired State_ expressed declaritively
 
 _Configuration_ is a common feature of most software systems.
 By "Configuration", we mean _data that defines how a system or subsystem should behave_.
-This configuration data is distinct and separate from the data a system will process.
 
 For example, the same web server code may be running on thousands of different servers managed by hundreds of different companies.
 The behaviour of an individual webserver will differ based on how it is configured.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,0 +1,254 @@
+<!-- see https://github.com/yzhang-gh/vscode-markdown/blob/master/README.md#table-of-contents -->
+# GitOps Principles v0.1.0 <!-- omit in toc -->
+
+## ⚠️ THIS DOCUMENT IS A WORK IN PROGRESS AND SUBJECT TO PUBLIC REVIEW BEFORE PUBLICATION <!-- omit in toc --> ⚠️ 
+
+This document provides a concrete definition of GitOps principles.
+
+The GitOps Principles are vendor and implementation neutral, and aim to provide a common understanding of GitOps systems, to enable a common framework of understanding beyond individual opinion. A second aim is to encourage innovation by clarifying the technical outcomes rather than the code, tests, or organizational elements needed to achieve them. 
+
+## Table of Content <!-- omit in toc -->
+
+<!-- Insert auto-generated toc here -->
+- [Summary](#summary)
+- [Introduction](#introduction)
+- [Scope](#scope)
+- [The GitOps Principles](#the-gitops-principles)
+  - [1. Declarative configuration](#1-declarative-configuration)
+    - [What is a system's Desired State?](#what-is-a-systems-desired-state)
+    - [Why must the Desired State be declarative data?](#why-must-the-desired-state-be-declarative-data)
+    - [Why is human readability required?](#why-is-human-readability-required)
+    - [How much of a system must be declared?](#how-much-of-a-system-must-be-declared)
+  - [2. Immutable configuration versions](#2-immutable-configuration-versions)
+    - [What forms a version?](#what-forms-a-version)
+  - [3. Continuous state reconciliation](#3-continuous-state-reconciliation)
+  - [4. Operations through declaration](#4-operations-through-declaration)
+- [See Also](#see-also)
+
+## Summary
+
+GitOps is a set of principles for operating and managing software systems.
+
+When using GitOps, the desired state of a system or subsystem is defined declaratively as versioned, immutable data, and the running system's configuration is continuously derived from this data.
+
+GitOps principles were derived from modern software operations but are rooted in pre-existing and widely adopted best practices. These principles are:
+
+1. [**The principle of declarative configuration**](#1-declarative-configuration)
+
+    A system managed by GitOps must have its _Desired State_ expressed declaritively as data.
+    This declarative data must be in a format writable and readable by both humans and software.
+
+2. [**The principle of immutable configuration versions**](#2-immutable-configuration-versions)
+
+    _Desired State_ is stored in a way that supports versioning, immutability of versions, and retains a complete version history.
+    We call systems that store desired state in this way _State Stores_.
+
+3. [**The principle of continuous state reconciliation**](#3-continuous-state-reconciliation)
+
+    Software agents continuously, and automatically, compare a system's _Actual State_ to its _Desired State_.
+    If the actual and desired states differ, automated actions are immediately attempted to reconcile them.
+    These differences could be due to the actual state drifting from the desired state, or the desired state changing intentionally.
+
+4. [**The principle of operations through declaration**](#4-operations-through-declaration)
+
+    When wishing to operate on a software system, a human or software agent will not interact with the running system and modify it directly.
+    Instead, the agent will create a new declarative version of the desired state in the state store.
+
+## Introduction
+
+The software systems that we manage vary widely; from battery powered embedded systems driven by microcontrollers, to globally distributed applications with millions of users. 
+Most systems are composed of subsystems themselves made of software.
+It is impossible to comprehensively outline all the specific practices for managing such a variety of systems.
+
+However, despite the myriad differences, several important principles emerge that simplify the task of reliably managing and operating _all_ software systems at scale. GitOps attempts to capture some of these principles in a coherent framework.
+The GitOps principles can be applied to managing entire software systems or applied only to parts of larger systems.
+
+See also the [Rationale for GitOps](RATIONALE.md).
+
+## Scope
+
+GitOps concerns the verifiable behaviour of computer systems and their interfaces.
+Specifically, GitOps is _not_ about human processes, and is not intended as a model for judging human organisational designs and operational practices.
+
+The GitOps principles are to be used as guiding principles in the development of modern software and system operations. They do not form a concrete specification.
+
+The GitOps principles are a direction, not a destination. They should be applied pragmatically. For example, whilst desirable to apply them strictly to an entire software systems, they can also be applied loosely to selected parts of larger systems as part of a progressive adoption.
+
+## The GitOps Principles
+
+### 1. Declarative configuration
+
+<div style="background: #E3F2FD; border-left: 3px solid #0D47A1; padding:10px; margin-bottom:5px; font-style:italic">
+A system managed by GitOps must have its <em>Desired State</em> expressed declaritively as data.
+This declarative data must be in a format writable and readable by both humans and software.
+</div>
+
+#### What is a system's Desired State?
+
+_Configuration_ is a common feature of most software systems.
+By "Configuration", we mean _data that defines how a system or subsystem will behave and operate_.
+This configuration data is distinct and separate from the data a system will process.
+
+For example, the same web server code may be running on thousands of different servers managed by hundreds of different companies.
+The behaviour of an individual webserver will differ based on how it is configured.
+Configuration data is typically in the form of files or arguments to a computer program, but some systems may also currently use configuration databases or remote configuration services. Configuration also includes data about what version of code a software system should run, so software version information is also considered configuration.
+
+Together, the aggregate of all configuration data for a system form its "Desired State". The "Desired State" of a system is defined as data sufficient to recreate the system from nothing so that instances of the system are behaviorally indinstinguishable.
+
+#### Why must the Desired State be declarative data?
+
+This is a subtle but important point.
+In deference to the work done by the Infrastructure as Code community (IaC), we believe that this was the intent of that movement to begin with.
+However, we have in practice seen a misunderstanding in this area, and many implementations have considered imperative scripts or programatic definitions for provisioning infrastructure to be a sufficient implementation of Infrastructure as Code. We disagree.
+
+We make the distinction explicitly for two important reasons:
+
+Firstly, it forces a separation of concerns between the Desired State (_what_ a system is) and _how_ the system is made to reach that state.
+This modular approach enables the implementation details of operations (the _how_) to be separated and iterated on independently from the system configuration (the _what_). 
+It also enables different tools and implementations to use the same Desired State declaration and interoperate against a common data language. 
+These modular systems are more flexible.
+For example, a Python program could verify a configuration file, while a C++ executable actually implements the declaration into a running system. Encoding the Desired State with a programming language ties the implementation to it, or forces other components to create a fully featured interpreter.
+
+Secondly, verifying the correctness and self-consistency of data is significantly less complex than verifying the correctness of a program's behaviour, which is fundamentally undecidable. 
+Verifying that a set of declarations is correct, however, _is_ decidable, even if sometimes computationally expensive.
+As a general rule, this implies that the data language used to defined the Desired State should have no control flow structure, and consist exclusively of referentially transparent expressions without side effects. 
+In other words, a human-readable data-serialization format.
+
+It is also preferrable to use a widely supported language to define the Desired State for the sake of interoperability. For example, YAML, XML, JSON and TOML all have broad support and well defined specifications, although there are many other suitable candidates.
+
+#### Why is human readability required?
+
+Operationally, it has been proven time and time again that the canonical Desired State of a system should be human-readable and writable.
+
+The Desired State encodes the _intent_ of a system. For example, where internet traffic should be routed. The collection of decisions about a system captured in its Desired State are of particular interest to its human operators. They must be able to directly describe their intent about the state of a system; and similarly, must be able to decipher the intended state of a system from its configuration.
+
+This principles not only capture a requirement about the format of the configuration, but also the qualitative readability of configuration _in practice_. For example, a simple YAML or XML file can be easily read, understood and modified by human operators, but experience has taught us that these formats also allow the creation of complex self-referential documents beyond the ability of most humans to interpret. Such complex document would violate this principles, even though the formats are, on the surface, human-readable.
+
+This relative readability also implies that the users are relevant when evaluating whether a system follows this principle. For example, a Desired State defined with a rich grammar of S-Expressions would suite a team of developers with a background in functional programming, but would violate this principle if the majority of the team found the format incomprehensible.
+
+Having a human-readable Desired State does not in any way preclude the use of rich tooling or graphical interfaces that facilitate Desired State generation and interpretation. It only require that the canonical source of truth be human readable and writable plain text.
+
+#### How much of a system must be declared?
+
+Ideally, all of it; and the entire system can be recreated exclusively from its Desired State.
+
+That said, the definition of a "computer systems" can be quite broad and strays into human processes and systems as well. 
+For example, is a company's sales process a "computer system"? 
+Likely in parts. 
+Should GitOps be applied to the entire sales process including the human processes (without prejudice as to what those processes are)? 
+Whilst such a vision is compelling, a more pragmatic approach is preferrable, otherwise we risk trying to boil the ocean.
+
+Instead, we should focus on subsystems where the Desired State is well defined, implement the GitOps principles there, and grow out to capture more systems from that initial subsystem. <!-- This progressive approach to GitOps is elaborated further in [the guide to adopting GitOps.md](ADOPTING_GITOPS.md). -->
+
+### 2. Immutable configuration versions
+
+<div style="background: #E3F2FD; border-left: 3px solid #0D47A1; padding:10px; margin-bottom:5px; font-style:italic">
+<em>Desired State</em> is stored in a way that supports versioning, immutability of versions, and retains a complete version history.
+We call systems that store Desired State in this way <em>State Stores</em>.
+</div>
+
+#### What forms a version?
+
+A version is the Desired State for a system as a whole. It is the canonical form of what we desire the system to be at a point in time.
+
+It is insufficient to version part of the Desired State or to version these parts in separate State Stores. Real software systems often have overarching behaviour that is the result of coupling between components. If the Desired State of these components were to change independently, it would be difficult to map a change in observed behaviour of our system to a single change in Desired State. Being able to make this 1:1 mapping is operationally benefitial, as we can then map behavioural issues of our system directly to the changes that occured. The utility of having the entire system defined in a single canonical location grows in proportion to the complexity and internal coupling of the system. A web of references to configuration data located in different locations is undesirable, as it makes understanding the desired state particularly difficult.
+
+Versions should be uniquely named. This need not be a semantically meanigful name. It is sufficient that each new version is attributed a name that identifies it uniquely. Once a new version has been created, it should be immutable. By this we mena that it should be impossible to modify the relationship between a version's unique name and its value of the Desired State. 
+
+All versions, except to very first,  should also have reference a predecessor or parent, which is another uniquely named version. This enables us to retain a history of the changes.
+
+<!--
+#### Why is it necessary to have versions be immutable and retained indefinitely?
+
+
+
+- only verb is to create a new version.
+This - Only uniquely named new versions of the system configuration can be created and all configuration info is retained (forward only)
+- rollback
+- Audit
+The only exception being in the case of sensitive information leaks due to error.
+  (I would agrue that key rotation is always better option in this case, but for PII and proprietary info this isn't possible).
+- changes as transactions
+
+#### What are the responsibilities of a State store?
+- In addition, state stores must preserve metadata information regarding the identity of agents that create new versions.
+The Desired State of the new version, Who created it, when it was created and ideally, also _why_ it was created. - What Why, who when. 
+
+- Even though we say git, it's actually only true when configured in a very particular way.
+
+#### State stores as coordination points/ collab via common data interface
+- Collab point. 
+- Business rules and security rules about the acceptable state of the system shoudl be checked against any new proposed version of the desired configuration before such changes are accepted as a new version. (Gates before version)
+- where human process is integrated
+- the place where collaboration can be synchronised.
+-->
+
+### 3. Continuous state reconciliation
+
+<div style="background: #E3F2FD; border-left: 3px solid #0D47A1; padding:10px; margin-bottom:5px; font-style:italic">
+Software agents continuously, and automatically, compare a system's <em>Actual State</em> to its <em>Desired State</em>.
+If the actual and desired states differ, automated actions are immediately attempted to reconcile them.
+These differences could be due to the actual state drifting from the desired state, or the desired state changing intentionally.
+</div>
+
+<!--
+- If the software agents fail to bring the system's state in line with its desired state, a human operator is notified.
+- Software agents continuously check that the running system under management matches the desired state configuration, and if it does not, immediately either take remedial action to bring the system back in line with stated expectations or, if this cannot be done, alert a human operator that the system is no longer meeting expectations
+- Automated delivery: Delivery of the declarative descriptions, from the repository to runtime environment, is fully automated.
+- Software Agents: Reconcilers maintain system state and apply the resources described in the declarative configuration.
+- Closed loop: Actions are performed on divergence between the version controlled declarative configuration and the actual state of the target system.
+- This automation should serve its human users.
+  To this point, reconciliation automation for GitOps should include a way for humans to temporarily take back the reins as needed.
+- Implies observability. State of the running system must be observable. Ideally in same format as the configuration so we can compare like to like. 
+- >I agree. I think of this as an observability requirement and tend to say that "the current state of a running system must be observable" to mean the same thing. This is, in my opinion, required for state reconciliation. I didn't add a note there explicitly though, as that section was unfinished.
+-->
+
+
+### 4. Operations through declaration
+
+<div style="background: #E3F2FD; border-left: 3px solid #0D47A1; padding:10px; margin-bottom:5px; font-style:italic">
+When wishing to operate on a software system, a human or software agent will not interact with the running system and modify it directly.
+Instead, the agent will create a new declarative version of the desired state in the state store.
+</div>
+<!--
+- All normal operations should occur via the creation of a new uniquely named version, not through direct interaction ith the system under management
+- Break glass - exceptions are acceptable and quite likely. and credentials to access and mutate the system must still be available in almost all cases.
+-->
+
+<!--
+## General notes on the GitOps principles
+
+- Tool and system agnosticicsm.
+  
+- It's ok to be pragmatic with implementations - We recognise that few real systems can be “100% GitOps”.
+  Real world systems have a lifetime measured in years and must interact with many other systems created under alternative paradigms.
+  As such they involve compromises and workarounds.
+  
+- lowest turtle isn't declarative, because the real world isn't.
+  We aim for the lowest turtle to be as small as possible (imperative surface area )
+
+- Git as a satte store: - the "state store" can be a subfolder in a particular branch, and repo.
+  Principles only applies to the data used to configure a running system, not other data in the same git repository.
+
+- The human interface can be whatever - GitOps doesn't mean the absence of a rich user experience or restrictions to the CLI
+
+## Prior Art
+
+- Whitehorse: https://www.zdnet.com/article/microsoft-places-bet-on-whitehorse/
+- IaC
+- Functional-Reactive programming (http://conal.net/papers/icfp97/icfp97.pdf)
+- OODA loop
+
+For naming discussion see <https://github.com/gitops-working-group/gitops-working-group/issues/8>
+
+
+- [Common GitOps Practices](PRACTICES.md)
+- [GitOps Compared to Other Practices]()
+- [The GitOps adoption Journey]()
+- [GitOps Patterns]()
+
+-->
+
+## See Also
+
+- [The GitOps Glossary](GLOSSARY.md)

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -51,8 +51,7 @@ GitOps principles were derived from modern software operations but are rooted in
 
 4. [**The principle of operations through declaration**](#4-operations-through-declaration)
 
-    When wishing to operate on a software system, a human or software agent will not interact with the running system and modify it directly.
-    Instead, the agent will create a new declarative version of the desired state in the state store.
+    The mechanism through which change is applied to a system by either a human operator or another system is through the creation of a new declarative version of the desired state in the state store, not through directly interacting with the running system.
 
 ## Introduction
 
@@ -209,8 +208,7 @@ These differences could be due to the actual state drifting from the desired sta
 ### 4. Operations through declaration
 
 <div style="background: #E3F2FD; border-left: 3px solid #0D47A1; padding:10px; margin-bottom:5px; font-style:italic">
-When wishing to operate on a software system, a human or software agent will not interact with the running system and modify it directly.
-Instead, the agent will create a new declarative version of the desired state in the state store.
+The mechanism through which change is applied to a system by either a human operator or another system is through the creation of a new declarative version of the desired state in the state store, not through directly interacting with the running system.
 </div>
 <!--
 - All normal operations should occur via the creation of a new uniquely named version, not through direct interaction ith the system under management

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -56,12 +56,14 @@ GitOps principles were derived from modern software operations but are rooted in
 
 ## Introduction
 
-The software systems that we manage vary widely; from battery powered embedded systems driven by microcontrollers, to globally distributed applications with millions of users. 
-Most systems are composed of subsystems themselves made of software.
-It is impossible to comprehensively outline all the specific practices for managing such a variety of systems.
+The systems that we manage vary widely; from battery-powered devices driven by microcontrollers to globally distributed systems with millions and sometimes billions of users. 
 
-However, despite the myriad differences, several important principles emerge that simplify the task of reliably managing and operating _all_ software systems at scale. GitOps attempts to capture some of these principles in a coherent framework.
-The GitOps principles can be applied to managing entire software systems or applied only to parts of larger systems.
+What is common across all systems is the need for human operators to make changes to the running state, it is during change that systems are most at risk of failure. 
+
+GitOps is a framework in which all change is applied to a system in a consistent mechanism that both reduces risk and improves the situational awareness of human operators working inside the system.
+
+
+GitOps can be applied to managing large systems or applied only to the smaller sub-system.
 
 See also the [Rationale for GitOps](RATIONALE.md).
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -86,7 +86,7 @@ This declarative data must be in a format writable and readable by both humans a
 #### What is a system's Desired State?
 
 _Configuration_ is a common feature of most software systems.
-By "Configuration", we mean _data that defines how a system or subsystem will behave and operate_.
+By "Configuration", we mean _data that defines how a system or subsystem should behave_.
 This configuration data is distinct and separate from the data a system will process.
 
 For example, the same web server code may be running on thousands of different servers managed by hundreds of different companies.
@@ -124,7 +124,7 @@ The Desired State encodes the _intent_ of a system. For example, where internet 
 
 This principles not only capture a requirement about the format of the configuration, but also the qualitative readability of configuration _in practice_. For example, a simple YAML or XML file can be easily read, understood and modified by human operators, but experience has taught us that these formats also allow the creation of complex self-referential documents beyond the ability of most humans to interpret. Such complex document would violate this principles, even though the formats are, on the surface, human-readable.
 
-This relative readability also implies that the users are relevant when evaluating whether a system follows this principle. For example, a Desired State defined with a rich grammar of S-Expressions would suite a team of developers with a background in functional programming, but would violate this principle if the majority of the team found the format incomprehensible.
+This relative readability also implies that the users are relevant when evaluating whether a system follows this principle. For example, the Desired State defined with a rich grammar of S-Expressions would suit a team of developers with a background in functional programming but would violate this principle if the majority of the team found the format incomprehensible.
 
 Having a human-readable Desired State does not in any way preclude the use of rich tooling or graphical interfaces that facilitate Desired State generation and interpretation. It only require that the canonical source of truth be human readable and writable plain text.
 
@@ -151,11 +151,11 @@ We call systems that store Desired State in this way <em>State Stores</em>.
 
 A version is the Desired State for a system as a whole. It is the canonical form of what we desire the system to be at a point in time.
 
-It is insufficient to version part of the Desired State or to version these parts in separate State Stores. Real software systems often have overarching behaviour that is the result of coupling between components. If the Desired State of these components were to change independently, it would be difficult to map a change in observed behaviour of our system to a single change in Desired State. Being able to make this 1:1 mapping is operationally benefitial, as we can then map behavioural issues of our system directly to the changes that occured. The utility of having the entire system defined in a single canonical location grows in proportion to the complexity and internal coupling of the system. A web of references to configuration data located in different locations is undesirable, as it makes understanding the desired state particularly difficult.
+It is insufficient to version part of the Desired State or to version these parts in separate State Stores. Real software systems often have overarching behaviour that is the result of coupling between components. If the Desired State of these components were to change independently, it would be difficult to map a change in observed behaviour of our system to a single change in Desired State. Being able to make this 1:1 mapping is operationally beneficial, as we can then map behavioural issues of our system directly to the changes that occured. The utility of having the entire system defined in a single canonical location grows in proportion to the complexity and internal coupling of the system. A web of references to configuration data located in different locations is undesirable, as it makes understanding the desired state particularly difficult.
 
-Versions should be uniquely named. This need not be a semantically meanigful name. It is sufficient that each new version is attributed a name that identifies it uniquely. Once a new version has been created, it should be immutable. By this we mena that it should be impossible to modify the relationship between a version's unique name and its value of the Desired State. 
+Versions should be uniquely named. This need not be a semantically meaningful name. It is sufficient that each new version is attributed a name that identifies it uniquely. Once a new version has been created, it should be immutable. By this we mean that it should be impossible to modify the relationship between a version's unique name and its value of the Desired State. 
 
-All versions, except to very first,  should also have reference a predecessor or parent, which is another uniquely named version. This enables us to retain a history of the changes.
+All but the very first version should reference a predecessor or parent, which is another uniquely named version. This enables us to retain a history of the changes.
 
 <!--
 #### Why is it necessary to have versions be immutable and retained indefinitely?
@@ -227,8 +227,8 @@ Instead, the agent will create a new declarative version of the desired state in
 - lowest turtle isn't declarative, because the real world isn't.
   We aim for the lowest turtle to be as small as possible (imperative surface area )
 
-- Git as a satte store: - the "state store" can be a subfolder in a particular branch, and repo.
-  Principles only applies to the data used to configure a running system, not other data in the same git repository.
+- Git as a state store: - the "state store" can be a subfolder in a particular branch, and repo.
+  Principles only applies to the data used to configure a running system, not other data in the same git repository nor runtime application data.
 
 - The human interface can be whatever - GitOps doesn't mean the absence of a rich user experience or restrictions to the CLI
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -5,7 +5,9 @@
 
 This document provides a concrete definition of GitOps principles.
 
-The GitOps Principles are vendor and implementation neutral, and aim to provide a common understanding of GitOps systems, to enable a common framework of understanding beyond individual opinion. A second aim is to encourage innovation by clarifying the technical outcomes rather than the code, tests, or organizational elements needed to achieve them. 
+The GitOps principles governs how humans and technical systems should interact in order to achieve the desired operational outcomes of repeatability, auditability, and visibility.
+
+The GitOps Principles are vendor and implementation neutral, they aim to provide a common framework of understanding regarding software operating softwrae systems.
 
 ## Table of Content <!-- omit in toc -->
 
@@ -133,11 +135,10 @@ Having a human-readable Desired State does not in any way preclude the use of ri
 
 Ideally, all of it; and the entire system can be recreated exclusively from its Desired State.
 
-That said, the definition of a "computer systems" can be quite broad and strays into human processes and systems as well. 
-For example, is a company's sales process a "computer system"? 
-Likely in parts. 
-Should GitOps be applied to the entire sales process including the human processes (without prejudice as to what those processes are)? 
-Whilst such a vision is compelling, a more pragmatic approach is preferrable, otherwise we risk trying to boil the ocean.
+The definition of a _system_ can be quite broad, and may incorporate human as well as programmatic processes.
+For example, is a company's sales process a system?
+Should GitOps be applied to it?
+Although a vision in which the GitOps practices are applied generally to all processes, human or otherwise is compelling, a more pragmatic approach is preferable, to avoid the risk of attempting to "boil the ocean".
 
 Instead, we should focus on subsystems where the Desired State is well defined, implement the GitOps principles there, and grow out to capture more systems from that initial subsystem. <!-- This progressive approach to GitOps is elaborated further in [the guide to adopting GitOps.md](ADOPTING_GITOPS.md). -->
 
@@ -152,7 +153,12 @@ We call systems that store Desired State in this way <em>State Stores</em>.
 
 A version is the Desired State for a system as a whole. It is the canonical form of what we desire the system to be at a point in time.
 
-It is insufficient to version part of the Desired State or to version these parts in separate State Stores. Real software systems often have overarching behaviour that is the result of coupling between components. If the Desired State of these components were to change independently, it would be difficult to map a change in observed behaviour of our system to a single change in Desired State. Being able to make this 1:1 mapping is operationally beneficial, as we can then map behavioural issues of our system directly to the changes that occured. The utility of having the entire system defined in a single canonical location grows in proportion to the complexity and internal coupling of the system. A web of references to configuration data located in different locations is undesirable, as it makes understanding the desired state particularly difficult.
+It is insufficient to version part of the Desired State or to version these parts in separate State Stores.
+In practice, software systems often have overarching behaviour that is the result of coupling between components.
+If the Desired State of these components were to change independently, it would be difficult to map a change in observed behaviour of our system to a single change in Desired State.
+Being able to make this 1:1 mapping is operationally beneficial, as we can then map behavioural issues of our system directly to the changes that occured.
+The utility of having the entire system defined in a single canonical location grows in proportion to the complexity and internal coupling of the system.
+A web of references to configuration data located in different locations is undesirable, as it makes understanding the desired state particularly difficult.
 
 Versions should be uniquely named. This need not be a semantically meaningful name. It is sufficient that each new version is attributed a name that identifies it uniquely. Once a new version has been created, it should be immutable. By this we mean that it should be impossible to modify the relationship between a version's unique name and its value of the Desired State. 
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -56,12 +56,11 @@ GitOps principles were derived from modern software operations but are rooted in
 
 ## Introduction
 
-The systems that we manage vary widely; from battery-powered devices driven by microcontrollers to globally distributed systems with millions and sometimes billions of users. 
+The systems that we manage vary widely; from battery-powered devices driven by microcontrollers to globally distributed systems with millions and sometimes billions of users.
 
-What is common across all systems is the need for human operators to make changes to the running state, it is during change that systems are most at risk of failure. 
+What is common across all systems is the need for human operators to make changes to the running state, it is during change that systems are most at risk of failure.
 
 GitOps is a framework in which all change is applied to a system in a consistent mechanism that both reduces risk and improves the situational awareness of human operators working inside the system.
-
 
 GitOps can be applied to managing large systems or applied only to the smaller sub-system.
 
@@ -69,12 +68,15 @@ See also the [Rationale for GitOps](RATIONALE.md).
 
 ## Scope
 
-GitOps concerns the verifiable behaviour of computer systems and their interfaces.
-Specifically, GitOps is _not_ about human processes, and is not intended as a model for judging human organisational designs and operational practices.
+GitOps concerns the interaction between humans and technical systems, and between technical systems.
+GitOps is not concerned with processes of human decision making or organisation, only how human decisions about technical systems are recorded and applied.
+It is a structured process through which technical systems can be modified reliably.
+
+GitOps is _not_ intended as a model for judging human organisational designs.
 
 The GitOps principles are to be used as guiding principles in the development of modern software and system operations. They do not form a concrete specification.
 
-The GitOps principles are a direction, not a destination. They should be applied pragmatically. For example, whilst desirable to apply them strictly to an entire software systems, they can also be applied loosely to selected parts of larger systems as part of a progressive adoption.
+The GitOps principles are a _direction_, **not** a _destination_. They should be applied pragmatically. For example, whilst desirable to apply them strictly to an entire systems, they can also be applied selectively to sub-systems as part of a progressive adoption.
 
 ## The GitOps Principles
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -7,7 +7,7 @@ This document provides a concrete definition of GitOps principles.
 
 The GitOps principles governs how humans and technical systems should interact in order to achieve the desired operational outcomes of repeatability, auditability, and visibility.
 
-The GitOps Principles are vendor and implementation neutral, they aim to provide a common framework of understanding regarding software operating softwrae systems.
+The GitOps Principles are vendor and implementation neutral, they aim to provide a common framework of understanding regarding software operations.
 
 ## Table of Content <!-- omit in toc -->
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -119,7 +119,7 @@ It is also preferrable to use a widely supported language to define the Desired 
 
 #### Why is human readability required?
 
-Operationally, it has been proven time and time again that the canonical Desired State of a system should be human-readable and writable.
+Operationally, it has been proven time and time again that the canonical Desired State of a system should be human-readable and writable. (See _The UNIX Philosophy (1995) by Mike Gancarz_ and _The Pragmatic Programmer (2000) Section 14 "The Power of Plain Text" by Andrew Hunt and David Thomas_)
 
 The Desired State encodes the _intent_ of a system. For example, where internet traffic should be routed. The collection of decisions about a system captured in its Desired State are of particular interest to its human operators. They must be able to directly describe their intent about the state of a system; and similarly, must be able to decipher the intended state of a system from its configuration.
 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -7,7 +7,7 @@ This leads to several serious issues:
 
 - **Detecting drift from desired state**
 
-    If the desired state of a system is not explicitly defined, it is impossible to verify if the system in a correct state. The state of a running system itself does not provide sufficent information to determine its correctness. 
+    If the desired state of a system is not explicitly defined, it is impossible to verify if the system in a correct state. The state of a running system itself does not provide sufficient information to determine its correctness. 
     
     Consider logging into an administration console and seeing that 28 machines are healthily running.
     Is this good? Is this bad? That very much depends on what the desired number of machines is.
@@ -27,7 +27,7 @@ This leads to several serious issues:
     
     We are left with the option of backing up our system state before a change so that we can restore a known good state if something goes wrong.
     This doesn't solve the problem of how to change our system to move to a new desired state. The best we can do is restore and retry. 
-    This becomes extremely common in complex distributed systems, where transient failures are common.
+    This becomes extremely common in complex distributed systems, where transient failures are usual.
     Such an approach is painful in practice and leads to an aversion to changing the system's state.
     
     This problem can be solved by having software agents that continuously converge the system towards a well-defined state. 
@@ -37,7 +37,7 @@ This leads to several serious issues:
     In most cases, we not only require the ability to change a running system safely, but we must also record what was changed, when, by whom, and why and enforce rules about which changes we allow.
     If our systems are changed through direct access, the surface area of the interface to control and monitor can quickly become overwhelmingly large. 
     
-    Access control at different levels, from the network to the application layer must be controlled and audited. A coherent set of access control rules must be applied across varied systems configured in completely different, and sometimes incompatible, ways. 
+    Access control at different levels, from the network to the application layer must be controlled and audited. A coherent set of access control rules must be applied across varied systems configured in completely different, and sometimes incompatible ways. 
     An audit trail may or may not be required for regulatory or governance reasons, but it is such a common requirement of managing software systems that it must be also be addressed.
     
     Having a single source of truth regarding the desired state of our system becomes a ledger of transactions between states and a single point of operation. This leads to a natural place to enforce rules regarding access and to audit changes. 

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -21,7 +21,7 @@ This leads to several serious issues:
 
     If we have no record of the desired state of our system, how can we recover from failures that occur in the transition between states? 
     Such transitions are very common lifecycle events, such as upgrades, new features being released or scaling our resources. These are where the majority of hard software defects and transient errors occur.
-    Not only are such failures extremely common, but their likelihood grows algebraically with the number of components in our system.
+    Not only are such failures extremely common, but their likelyhood grows quadratically with the number of components in our system, as they scale not with the number of components, but the number of connections between components, which can also fail independently of components.
     
     When these failures occur, they leave our system in an indeterminate transitional state. Going back to a known good state or forward to a new desired states is difficult, as we don't have a record of what these should be, only lists of instructions
     

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,49 @@
+# Rationale for GitOps
+
+Currently, many software system's desired state is not defined separately from the running system.
+When we desire the behaviour of a software system to change, we modify the system's configuration directly, either through human action, or by running scripts that take a set of predetermined action on the system.
+
+This leads to several serious issues:
+
+- **Detecting drift from desired state**
+
+    If the desired state of a system is not explicitly defined, it is impossible to verify if the system in a correct state. The state of a running system itself does not provide sufficent information to determine its correctness. 
+    
+    Consider logging into an administration console and seeing that 28 machines are healthily running.
+    Is this good? Is this bad? That very much depends on what the desired number of machines is.
+    For example, these could be test machines that should have been deleted and are now incurring a significant cost for no reasons, or all that remains of a 100 machine datacenter.
+    We could consult the documentation, or expect the human operator to know, but by the time this occurs, our system has been in an incorrect state for a significant period of time. _The validity of the state of our system is not automatically verifiable_.
+
+    This problem leads to the conclusion that the canonical source of truth for desired state cannot be the actual state. 
+    Making the desired state of a system explicit prevents this problem.
+    
+- **Recovering from transitional states**
+
+    If we have no record of the desired state of our system, how can we recover from failures that occur in the transition between states? 
+    Such transitions are very common lifecycle events, such as upgrades, new features being released or scaling our resources. These are where the majority of hard software defects and transient errors occur.
+    Not only are such failures extremely common, but their likelihood grows algebraically with the number of components in our system.
+    
+    When these failures occur, they leave our system in an indeterminate transitional state. Going back to a known good state or forward to a new desired states is difficult, as we don't have a record of what these should be, only lists of instructions
+    
+    We are left with the option of backing up our system state before a change so that we can restore a known good state if something goes wrong.
+    This doesn't solve the problem of how to change our system to move to a new desired state. The best we can do is restore and retry. 
+    This becomes extremely common in complex distributed systems, where transient failures are common.
+    Such an approach is painful in practice and leads to an aversion to changing the system's state.
+    
+    This problem can be solved by having software agents that continuously converge the system towards a well-defined state. 
+    
+- **Controlling and auditing actors, access and actions**
+    
+    In most cases, we not only require the ability to change a running system safely, but we must also record what was changed, when, by whom, and why and enforce rules about which changes we allow.
+    If our systems are changed through direct access, the surface area of the interface to control and monitor can quickly become overwhelmingly large. 
+    
+    Access control at different levels, from the network to the application layer must be controlled and audited. A coherent set of access control rules must be applied across varied systems configured in completely different, and sometimes incompatible, ways. 
+    An audit trail may or may not be required for regulatory or governance reasons, but it is such a common requirement of managing software systems that it must be also be addressed.
+    
+    Having a single source of truth regarding the desired state of our system becomes a ledger of transactions between states and a single point of operation. This leads to a natural place to enforce rules regarding access and to audit changes. 
+
+    Furthermore, by removing direct access, the credentials used to manage a system can be constrained to exist only within the security boundary of the system itself, which can poll its desired state. This greatly reduces the security surface area.
+
+These are only a small sample of the issues that arise if we do not define the desired state of our software systems explicitly and declaratively. We believe GitOps is a solution to these many issues that plague software operations at scale. 
+
+Since these issues occur so universally when operating software systems, we also believe that GitOps is fundamentally agnostic about specific tools. that is, the GitOps principles are universally applicable, and independent of any particular tool, solution or practice, including Git itself, after which they are named.

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -21,7 +21,7 @@ This leads to several serious issues:
 
     If we have no record of the desired state of our system, how can we recover from failures that occur in the transition between states? 
     Such transitions are very common lifecycle events, such as upgrades, new features being released or scaling our resources. These are where the majority of hard software defects and transient errors occur.
-    Not only are such failures extremely common, but their likelyhood grows quadratically with the number of components in our system, as they scale not with the number of components, but the number of connections between components, which can also fail independently of components.
+    Not only are such failures extremely common, but their likelihood grows quadratically with the number of components in our system, as failure may not only occur in each component, but also in the connections between components, which can fail independently.
     
     When these failures occur, they leave our system in an indeterminate transitional state. Going back to a known good state or forward to a new desired states is difficult, as we don't have a record of what these should be, only lists of instructions
     

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # gitops-working-group
 
+## GitOps
+
+Gitops is a set of [Principles](PRINCIPLES.md) for operating software systems, which addresses a set of [common issues](Rationale.md) with software operations.
+
 ## Announcing the GitOps Working Group
 
 On November 19, 2020, Amazon, Codefresh, GitHub, Microsoft, and Weaveworks are announcing the creation of the GitOps Working Group. This will be an open CNCF community project created inside the CNCF [gitops-working-group GitHub organization](https://github.com/gitops-working-group) as the initial venue for collaboration and open governance.
@@ -11,31 +15,6 @@ The group’s initial task will be to deliver a GitOps Manifesto which clearly d
 ### Growing Adoption of GitOps
 
 The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of services from Amazon, Codefresh, GitHub, Microsoft, Weaveworks, and hundreds of other leading global companies that are adopting GitOps. This, combined with the recommendation by the Cloud Native Computing Foundation (CNCF) [user community to adopt Flux](https://radar.cncf.io/2020-06-continuous-delivery), made it clear that GitOps is fast becoming the methodology of choice for operating modern cloud native infrastructure and applications. The CNCF user community reported that development, DevOps, and operations teams who adopt GitOps tooling and follow best practices experience improvements in productivity, stability, reliability, and security for their cloud native environments.
-
-### The What and Why of GitOps
-
-If you are new to GitOps, [it builds and iterates](https://www.weave.works/blog/gitops-operations-by-pull-request) on ideas drawn from DevOps and Infrastructure as Code that started with [Martin Fowler’s comprehensive Continuous Integration overview](https://martinfowler.com/articles/continuousIntegration.html) and provides the freedom to choose the tools that you need for your specific use cases.
-
-Individuals, teams, and organizations who implement GitOps experience many benefits, including:
-
-- Increased Developer & Operational Productivity
-- Enhanced Developer Experience
-- Improved Stability
-- Higher Reliability
-- Consistency and Standardization
-- Stronger Security Guarantees
-
-### GitOps Principles
-
-To give participants in the cloud native ecosystem clarity on what GitOps means, and by extension to realize these benefits, the creators of this working group defined these five core GitOps Principles that are at the foundation of GitOps practices.
-
-The Five GitOps Principles are as follows:
-
-1. **Declarative Configuration**: All resources managed through a GitOps process must be completely expressed declaratively.
-2. **Version controlled, immutable storage**: Declarative descriptions are stored in a repository that supports immutability, versioning and version history. For example, git.
-3. **Automated delivery**: Delivery of the declarative descriptions, from the repository to runtime environment, is fully automated.
-4. **Software Agents**: Reconcilers maintain system state and apply the resources described in the declarative configuration.
-5. **Closed loop**: Actions are performed on divergence between the version controlled declarative configuration and the actual state of the target system.
 
 ### An open working group
 

--- a/recipes/SETTING_UP_GIT.md
+++ b/recipes/SETTING_UP_GIT.md
@@ -1,0 +1,2 @@
+# Setting up Git as a State Store
+


### PR DESCRIPTION
## Current plan

- [x] Jumped back into this PR. Work was put on hold for a short time, but there are still things we can do to move this ahead
- [x] Everyone's thoughts to be discussed at the next working group meeting ([Mar 11, 2021](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.7g5ep31z1bvg))
- [x] Schedule one or more real-time working session with the group soon thereafter 
    1. The goal of this session is to come to a place where all concerns are addressed, and bring this PR to a mergeable first iteration. Note merging to main will still be subject to change, but something people can begin engaging with when visiting this repo
    1. This PR (or linked) will be the canonical source of truth (GitOps style)
    1.  During the sync sessions, we will "break out" into a Zoom conversation, and use hackmd.io which @bricef and @scottrigby initially collaborated on before moving that work to this PR. There we can co-edit in real time, preview the markdown as we go, leave any hackmd.io comments for posterity, and then ultimately move whatever agreed upon changes back to this PR as commits with descriptive comments and correct Co-author credit
- [x] Reach general consensus on the first pre-release of the GitOps Principles, revised by the GitOps WG ✅  yay!
- [x] New PR added to a repo in the OpenGitOps project org @scottrigby ✅  https://github.com/open-gitops/documents/pull/4

## Original PR description

This commit proposes a succinct definition of the GitOps principles with additional clarification.

Co-authored-by: Scott Rigby <scott@r6by.com>
Signed-off-by: Brice Fernandes <brice@weave.works>