### PR TITLE
Clarify relationship of WG to Sandbox project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,16 @@
-# gitops-working-group
+# GitOps Working Group
 
-## Announcing the GitOps Working Group
+The GitOps Working Group is a WG under the CNCF App Delivery SIG.
 
-On November 19, 2020, Amazon, Codefresh, GitHub, Microsoft, and Weaveworks are announcing the creation of the GitOps Working Group.
-This will be an open CNCF community project created inside the CNCF [gitops-working-group GitHub organization](https://github.com/gitops-working-group) as the initial venue for collaboration and open governance.
+The focus of the GitOps WG is to clearly define a vendor-neutral, principle-led meaning of GitOps. This will establish a foundation for interoperability between tools, conformance, and certification. Lasting programs, documents, and code are planned to live within the [OpenGitOps](https://github.com/open-gitops) project.
 
-The GitOps Working Group’s goal is to provide companies and individuals with the skills, knowledge and competency to implement GitOps tooling and methodologies which simplify the operation and management of infrastructure and cloud native applications.
-
-The group’s initial task will be to deliver a GitOps Manifesto which clearly defines the principles and technical aspects of GitOps.
-The GitOps Manifesto will be vendor and implementation neutral, and aims to grow a common understanding of GitOps systems based on shared principles, rather than a matter of individual opinion.
-A second aim is to encourage innovation by clarifying the technical outcomes rather than the code, tests, or organizational elements needed to achieve them.
-
-### Growing Adoption of GitOps
+## Growing Adoption of GitOps
 
 The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of services from Amazon, Codefresh, GitHub, Microsoft, Weaveworks, and hundreds of other leading global companies that are adopting GitOps.
 This, combined with the recommendation by the Cloud Native Computing Foundation (CNCF) [user community to adopt Flux](https://radar.cncf.io/2020-06-continuous-delivery), made it clear that GitOps is fast becoming the methodology of choice for operating modern cloud native infrastructure and applications.
 The CNCF user community reported that development, DevOps, and operations teams who adopt GitOps tooling and follow best practices experience improvements in productivity, stability, reliability, and security for their cloud native environments.
 
-### The What and Why of GitOps
+## The What and Why of GitOps
 
 If you are new to GitOps, [it builds and iterates](https://www.weave.works/blog/gitops-operations-by-pull-request) on ideas drawn from DevOps and Infrastructure as Code that started with [Martin Fowler’s comprehensive Continuous Integration overview](https://martinfowler.com/articles/continuousIntegration.html) and provides the freedom to choose the tools that you need for your specific use cases.
 
@@ -30,11 +23,15 @@ Individuals, teams, and organizations who implement GitOps experience many benef
 - Consistency and Standardization
 - Stronger Security Guarantees
 
-### GitOps Principles
+## GitOps Principles
 
-To give participants in the cloud native ecosystem clarity on what GitOps means, and by extension to realize these benefits, the creators of this working group defined these five core GitOps Principles that are at the foundation of GitOps practices.
+The group’s initial task – to "clearly define a vendor-neutral, principle-led meaning of GitOps" – is expressed as GitOps _Principles_, which are the foundation of GitOps practices.
 
-The Five GitOps Principles are as follows:
+This aims to give participants in the cloud native ecosystem a common understanding of GitOps systems based on shared principles, rather than a matter of individual opinion or implementation preference.
+
+🚧 The GitOps Principles are currently a work in progress. For current status, follow [PR #48](https://github.com/gitops-working-group/gitops-working-group/pull/48).
+
+🕠 In the meantime, you may refer to the initial [Draft Definition](https://docs.google.com/document/d/11EZfvB2FFI837nMmArnyv-wizsIJvc-4_xdgfoUXF4o/view), which proposes the principles as follows:
 
 1. **Declarative Configuration**: All resources managed through a GitOps process must be completely expressed declaratively.
 2. **Version controlled, immutable storage**: Declarative descriptions are stored in a repository that supports immutability, versioning and version history. For example, git.
@@ -42,38 +39,29 @@ The Five GitOps Principles are as follows:
 4. **Software Agents**: Reconcilers maintain system state and apply the resources described in the declarative configuration.
 5. **Closed loop**: Actions are performed on divergence between the version controlled declarative configuration and the actual state of the target system.
 
-### An open working group
+## How to Get Involved
 
-The founders of the GitOps Working Group are creating a neutral working group to clearly define a principle-lead meaning of GitOps to better enable interoperability between tools.
-With a clear definition, GitOps Certification Programs for individuals will also be possible.
-
-With today’s announcement of the GitOps Working Group, the group’s founders are inviting companies and individuals who are actively participating in the rapidly growing GitOps ecosystem to join this new community and help contribute to its success as a standard!
-
-### About the GitOps Manifesto
-
-The founders of the GitOps Working Group envision the creation of a GitOps Manifesto that will make it easier for companies to understand what the key principles of GitOps are while at the same time driving interoperability between tools that have incorporated these principles.
-
-### How to Get Involved
-
-With the announcement of the GitOps Working Group the founders would like to invite other companies to join the group and contribute to the community and the adoption of GitOps across the cloud native landscape.
+The GitOps Working Group is an open group, inviting companies and individuals to join and contribute to the community and the adoption of GitOps across the cloud native landscape.
 There are a few ways you can get involved:
 
-- Watch or star this repo to see when things change.
-- Attend a [Working Group meeting](./MEETINGS.md).
-- [Open an issue](/../../issues/new) and let us know how you're using GitOps and any important considerations we should include.
+- Watch or star this repo to see when things change
+- Attend a [Working Group meeting](./MEETINGS.md)
+- [Open an issue](/../../issues/new) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
+- Join the [SIG App Delivery](https://github.com/cncf/sig-app-delivery) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`
 
-We'll review all open issues and PRs at our regular working group meeting (schedule coming soon).
+The Working Group will review all open issues and PRs at our regular working group meeting (schedule coming soon).
 
-### Timeline
+## Timeline
 
-The goal of the GitOps Working Group’s founders is to: firstly, form the group during Q4 of 2020 and secondly, to establish V1 of the GitOps Manifesto by the end of March, 2021.
-If you are interested in keeping abreast of any new developments, please visit follow this repository.
+This timeline is a work in progress.
+If you are interested in keeping abreast of any new developments, please see [How to Get Involved](#how-to-get-involved).
 
-### Additional Information
-
-Documenting the GitOps principles, and supporting WG GitOps in CNCF App Delivery SIG as an OSS project.
-
-Please see [GitOps WG Charter](https://docs.google.com/document/d/11EZfvB2FFI837nMmArnyv-wizsIJvc-4_xdgfoUXF4o/view)
-and [Draft Definition](https://docs.google.com/document/d/11EZfvB2FFI837nMmArnyv-wizsIJvc-4_xdgfoUXF4o/view)
-for initial details. NOTE: We have moved the gitops definition into git - see PR #48
+| When | What |
+| -- | -- |
+| November 19, 2020 | Amazon, Codefresh, GitHub, Microsoft, and Weaveworks announced the creation of the GitOps Working Group. |
+| Q4 of 2020 | Form the group. Provisional governance bootstrapped. For details, see the initial [GitOps WG Charter](https://docs.google.com/document/d/11EZfvB2FFI837nMmArnyv-wizsIJvc-4_xdgfoUXF4o/view). |
+| End of March, 2021 | Establish a first version of the GitOps Principles |
+| Date TBD | Clearly established governance. For current status, follow [PR #40](https://github.com/gitops-working-group/gitops-working-group/discussions/40). |
+| March 19 - April 16, 2021 | [CFP open](https://docs.google.com/forms/d/e/1FAIpQLSeNahDbiEolx6WZmtxx4L65qmq7pZTX86nQAltq2uC12tCQYg/viewform) for GitOpsCon EU 2021 |
+| May 3, 2021 | GitOpsCon EU 2021. Pre-registration is required. See [Kubecon + CloudNativeCon Co-located events listing](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/colocated-events/#gitops-con) for details. |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ There are a few ways you can get involved:
 - [Open an issue](/../../issues/new) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
 - Join the [SIG App Delivery](https://github.com/cncf/sig-app-delivery) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`
+- See [Working Group project boards](https://github.com/orgs/gitops-working-group/projects) for status of work, or for ideas on areas that could use additional participation
 
 The Working Group will review all open issues and PRs at our regular working group meeting (schedule coming soon).
 


### PR DESCRIPTION
Now that https://github.com/gitops-working-group/gitops-working-group/discussions/64 is resolved, let's get this into code somewhere.

This PR updates the WG repo README about the relationship of WG to Sandbox project. In doing so, I also removed redundancies, brought things to the present tense, and added a more readable timeline.

Note there is also an [OpenGitOps](https://github.com/orgs/gitops-working-group/projects/6) GitHub project board to track progress needed for this, as it is guided by the GitHub Working Group, so let's keep this PR scope to just the WG README 😸 

~⚠️ DO NOT MERGE YET~
~This PR should not be merged until the name change is officially made by CNCF.~

Update: we have clarified this on the mailing list