### PR TITLE
chore: remove names of companies & projects in "Growing adoption.."

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ The focus of the GitOps WG is to clearly define a vendor-neutral, principle-led 
 
 The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of hundreds of leading global companies that are adopting GitOps.
 
-This, combined with the [CNCF End User Technology Radar]((https://radar.cncf.io/2020-06-continuous-delivery)) report by the [CNCF user community](https://www.cncf.io/people/end-user-community/) reported that development, DevOps, and operations teams who adopt GitOps tooling and follow best practices experience improvements in productivity, stability, reliability, and security for their cloud native environments.
+This, combined with the 
+[CNCF End User Technology Radar]((https://radar.cncf.io/2020-06-continuous-delivery)) report by 
+the [CNCF user community](https://www.cncf.io/people/end-user-community/) reported that development, 
+DevOps, and operations teams who adopt GitOps 
+tooling and follow best practices experience 
+improvements in productivity, stability, reliability, 
+and security for their cloud native environments.
 
 ## The What and Why of GitOps
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,8 @@ The focus of the GitOps WG is to clearly define a vendor-neutral, principle-led 
 ## Growing Adoption of GitOps
 
 The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of hundreds of leading global companies that are adopting GitOps.
-
-This, combined with the
-[CNCF End User Technology Radar]((https://radar.cncf.io/2020-06-continuous-delivery)) report by
-the [CNCF user community](https://www.cncf.io/people/end-user-community/) reported that development,
-DevOps, and operations teams who adopt GitOps
-tooling and follow best practices experience
-improvements in productivity, stability, reliability,
-and security for their cloud native environments.
+Additionally, the [CNCF End User Technology Radar on Continuous Delivery](https://radar.cncf.io/2020-06-continuous-delivery) made it clear that GitOps is fast becoming the methodology of choice for operating modern cloud native infrastructure and applications.
+The CNCF user community reported that development, DevOps, and operations teams who adopt GitOps tooling and follow best practices experience improvements in productivity, stability, reliability, and security for their cloud native environments.
 
 ## The What and Why of GitOps
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The focus of the GitOps WG is to clearly define a vendor-neutral, principle-led 
 
 ## Growing Adoption of GitOps
 
-The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of services from Amazon, Codefresh, GitHub, Microsoft, Weaveworks, and hundreds of other leading global companies that are adopting GitOps.
-This, combined with the recommendation by the Cloud Native Computing Foundation (CNCF) [user community to adopt Flux](https://radar.cncf.io/2020-06-continuous-delivery), made it clear that GitOps is fast becoming the methodology of choice for operating modern cloud native infrastructure and applications.
-The CNCF user community reported that development, DevOps, and operations teams who adopt GitOps tooling and follow best practices experience improvements in productivity, stability, reliability, and security for their cloud native environments.
+The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of hundreds of leading global companies that are adopting GitOps.
+
+This, combined with the [CNCF End User Technology Radar]((https://radar.cncf.io/2020-06-continuous-delivery)) report by the [CNCF user community](https://www.cncf.io/people/end-user-community/) reported that development, DevOps, and operations teams who adopt GitOps tooling and follow best practices experience improvements in productivity, stability, reliability, and security for their cloud native environments.
 
 ## The What and Why of GitOps
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ The focus of the GitOps WG is to clearly define a vendor-neutral, principle-led 
 
 The creation of the GitOps Working Group was driven by the accelerating adoption of GitOps tools and methodologies by users of hundreds of leading global companies that are adopting GitOps.
 
-This, combined with the 
-[CNCF End User Technology Radar]((https://radar.cncf.io/2020-06-continuous-delivery)) report by 
-the [CNCF user community](https://www.cncf.io/people/end-user-community/) reported that development, 
-DevOps, and operations teams who adopt GitOps 
-tooling and follow best practices experience 
-improvements in productivity, stability, reliability, 
+This, combined with the
+[CNCF End User Technology Radar]((https://radar.cncf.io/2020-06-continuous-delivery)) report by
+the [CNCF user community](https://www.cncf.io/people/end-user-community/) reported that development,
+DevOps, and operations teams who adopt GitOps
+tooling and follow best practices experience
+improvements in productivity, stability, reliability,
 and security for their cloud native environments.
 
 ## The What and Why of GitOps


### PR DESCRIPTION
I would like to propose we avoid using names of companies & projects in the "Growing adoption of GitOps" to ensure the group's promise to technology/vendor neutrality isn't diluted :) 

Note, the names of the founding members ( a huge thanks to the initiative! ) is present in the Timeline section.

Disclosure: 
I work for Red Hat, contribute to Argo and I love running Flux on OpenShift deployed on AWS :)