### PR TITLE
Point meetings doc to YouTube and organize by committee

### DIFF
--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -8,7 +8,7 @@ See the [Google Doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQH
 
 ## Working Group Monthly
 
-- May 13, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.lq3s56hyydm0) ⚠️ Note: May Monthly meeting moved to 3rd Thursday due to KubeCon EU
+- May 13, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.lq3s56hyydm0)
 - April 15, 2021: [recording](https://www.youtube.com/watch?v=c_GqwvP5Wqw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=5)
 - March 11, 2021: [recording](https://www.youtube.com/watch?v=P5Ib1CubO54&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=4)
 - February 11, 2021: [recording](https://www.youtube.com/watch?v=NilaC6Jhq_8&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=3)

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -23,5 +23,6 @@ See the [Google Doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQH
 
 ## GitOpsCon Committee Meetings
 
+- April 20, 2021: [recording](https://www.youtube.com/watch?v=V0qelLe3Xrs&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=3&ab_channel=CNCFGitOpsWorkingGroup), [chat](meetings/committee-gitopscon/2021-04-20-chat.txt)
 - April 15, 2021: [recording](https://www.youtube.com/watch?v=lwX5MBS1mk8&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=2), [chat](meetings/committee-gitopscon/2021-04-15-chat.txt)
 - April 06, 2021: [recording](https://www.youtube.com/watch?v=qNplG7Rw-YU&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=1), [chat](meetings/committee-gitopscon/2021-04-06-chat.txt)

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,32 +1,27 @@
-# GitOps Working Group Meetings
-The GitOps Working group typically meets on the second Thursday of each month at 18:00 GMT - this meeting can be found in the [CNCF calendar](https://www.cncf.io/calendar/).
-[Meeting Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+# Meetings
 
-## Upcoming Meetings
-### Thursday, April 15th at 18:00 GMT
-- [Video Conference Link](https://zoom.us/my/cncfgitopswg?pwd=aE9FMjR0M1djd3huMlNUMWZXSXpyQT09)
-- Meeting Passcode: `77777`
+The GitOps Working Group typically meets on the second Thursday of each month at 18:00 GMT, and are listed below. This meeting is also on the [CNCF calendar](https://www.cncf.io/calendar/).
 
-## Past Meetings
-### Thursday, March 11th at 18:00 GMT
+Additionally Working Group Committees meet as needed to complete their projects, and are also listed below.
 
-- [Video Recording](https://zoom.us/rec/share/SYMUyXzmVF4eLmO9d2N3AOQ3ror5cJo361pnz_PtxUnDMio0vXRd-qpjqMHPnGeo.J_6sc5Mv8IIKi9jr?startTime=1615486031000)
-- [Meeting Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+See the [Google Doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for detailed join info, agenda, and notes for all GitOps Working Group meetings.
 
-### Thursday, February 11th at 18:00 GMT
+## Working Group Monthly
 
-- [Video Recording](https://weaveworks.zoom.us/rec/share/OPy5MSMzgIkPX1-PAdhwrnGGa82Lr5BuVpQ1iSK-sbHPph68ML1JNVQXRKlP09bw.bjqDnPKEA2W9D2HG)
-- Passcode: `fwPy8^fb`
-- [Meeting Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+- May 13, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.lq3s56hyydm0) ⚠️ Note: May Monthly meeting moved to 3rd Thursday due to KubeCon EU
+- April 15, 2021: [recording](https://www.youtube.com/watch?v=c_GqwvP5Wqw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=5)
+- March 11, 2021: [recording](https://www.youtube.com/watch?v=P5Ib1CubO54&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=4)
+- February 11, 2021: [recording](https://www.youtube.com/watch?v=NilaC6Jhq_8&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=3)
+- January 14, 2021: [recording](https://www.youtube.com/watch?v=JypiRn8HTbw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=2)
+- December 10, 2020: [recording](https://www.youtube.com/watch?v=LnzIE6tDfbQ&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=1)
 
-### Thursday, January 14th at 17:00 GMT
+## GitOps Principles Committee Meetings
 
-- [Video Recording](https://weaveworks.zoom.us/rec/share/_qrMRze16IHb2d4KIOHSa2Wxb_XzbU41-ZH6YZI5aJkUqOHM1bBQLCQhkFva5xo0.ay0LdxTVPCTlgbSd)<br>
-- Passcode: `EpQ26^cV`
-- [Meeting Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+- April 14, 2021: [recording](https://www.youtube.com/watch?v=zWxAZuHNGYM&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=3)
+- April 05, 2021: [recording](https://www.youtube.com/watch?v=SGcSRTWnT3k&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=2)
+- March 29, 2021: [recording](https://www.youtube.com/watch?v=2VpbWrKjDkQ&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=1)
 
-### Thursday, December 10th at 17:00 GMT
+## GitOpsCon Committee Meetings
 
-- [Video Recording](https://weaveworks.zoom.us/rec/share/jyagKQsL7irvi1pF-RHzrrwH-Sqa59wNnBK0F2H8QYBo_rxJZOXMO-5j5CwUgKiK.9cl0var5BN-z0qrI)<br>
-- Passcode: `%mi$&f8e`
-- [Meeting Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/)
+- April 15, 2021: [recording](https://www.youtube.com/watch?v=lwX5MBS1mk8&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=2)
+- April 06, 2021: [recording](https://www.youtube.com/watch?v=qNplG7Rw-YU&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=1)

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -9,19 +9,19 @@ See the [Google Doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQH
 ## Working Group Monthly
 
 - May 13, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.lq3s56hyydm0)
-- April 15, 2021: [recording](https://www.youtube.com/watch?v=c_GqwvP5Wqw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=5)
-- March 11, 2021: [recording](https://www.youtube.com/watch?v=P5Ib1CubO54&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=4)
-- February 11, 2021: [recording](https://www.youtube.com/watch?v=NilaC6Jhq_8&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=3)
-- January 14, 2021: [recording](https://www.youtube.com/watch?v=JypiRn8HTbw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=2)
-- December 10, 2020: [recording](https://www.youtube.com/watch?v=LnzIE6tDfbQ&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=1)
+- April 15, 2021: [recording](https://www.youtube.com/watch?v=c_GqwvP5Wqw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=5), [chat](meetings/monthly/2021-04-15-chat.txt)
+- March 11, 2021: [recording](https://www.youtube.com/watch?v=P5Ib1CubO54&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=4), [chat](meetings/monthly/2021-03-11-chat.txt)
+- February 11, 2021: [recording](https://www.youtube.com/watch?v=NilaC6Jhq_8&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=3), [chat](meetings/monthly/2021-02-11-chat.txt)
+- January 14, 2021: [recording](https://www.youtube.com/watch?v=JypiRn8HTbw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=2), [chat](meetings/monthly/2021-01-14-chat.txt)
+- December 10, 2020: [recording](https://www.youtube.com/watch?v=LnzIE6tDfbQ&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=1), [chat](meetings/monthly/2020-12-10-chat.txt)
 
 ## GitOps Principles Committee Meetings
 
-- April 14, 2021: [recording](https://www.youtube.com/watch?v=zWxAZuHNGYM&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=3)
-- April 05, 2021: [recording](https://www.youtube.com/watch?v=SGcSRTWnT3k&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=2)
-- March 29, 2021: [recording](https://www.youtube.com/watch?v=2VpbWrKjDkQ&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=1)
+- April 14, 2021: [recording](https://www.youtube.com/watch?v=zWxAZuHNGYM&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=3), [chat](meetings/committee-principles/2021-04-14-chat.txt)
+- April 05, 2021: [recording](https://www.youtube.com/watch?v=SGcSRTWnT3k&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=2), [chat](meetings/committee-principles/2021-04-05-chat.txt)
+- March 29, 2021: [recording](https://www.youtube.com/watch?v=2VpbWrKjDkQ&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=1), [chat](meetings/committee-principles/2021-03-29-chat.txt)
 
 ## GitOpsCon Committee Meetings
 
-- April 15, 2021: [recording](https://www.youtube.com/watch?v=lwX5MBS1mk8&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=2)
-- April 06, 2021: [recording](https://www.youtube.com/watch?v=qNplG7Rw-YU&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=1)
+- April 15, 2021: [recording](https://www.youtube.com/watch?v=lwX5MBS1mk8&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=2), [chat](meetings/committee-gitopscon/2021-04-15-chat.txt)
+- April 06, 2021: [recording](https://www.youtube.com/watch?v=qNplG7Rw-YU&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=1), [chat](meetings/committee-gitopscon/2021-04-06-chat.txt)

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -23,6 +23,7 @@ See the [Google Doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQH
 
 ## GitOpsCon Committee Meetings
 
+- April 21, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.5z4kq9bei31m)
 - April 20, 2021: [recording](https://www.youtube.com/watch?v=V0qelLe3Xrs&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=3&ab_channel=CNCFGitOpsWorkingGroup), [chat](meetings/committee-gitopscon/2021-04-20-chat.txt)
 - April 15, 2021: [recording](https://www.youtube.com/watch?v=lwX5MBS1mk8&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=2), [chat](meetings/committee-gitopscon/2021-04-15-chat.txt)
 - April 06, 2021: [recording](https://www.youtube.com/watch?v=qNplG7Rw-YU&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=1), [chat](meetings/committee-gitopscon/2021-04-06-chat.txt)

--- a/meetings/committee-gitopscon/2021-04-06-chat.txt
+++ b/meetings/committee-gitopscon/2021-04-06-chat.txt
@@ -1,0 +1,27 @@
+00:06:16	Christian Hernandez:	https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.s5dinyjyr1t
+00:14:44	Christian Hernandez:	https://docs.google.com/document/d/14eHgAjFvbjRUMDl6uHX3bb1DQJvxRu6ddQPFX-e-wfY/edit
+00:16:08	Schlomo Schapiro:	Review Work Sheet: https://docs.google.com/spreadsheets/d/13r31KwCDjBXTrtsq-3ddwT2qFLnQEEannOO7cVlFXrM/edit?ts=60690147#gid=322767999
+00:21:30	Philippe Ensarguet:	And what about the ones who already applied? do we have a mean to know if they have a talk on KubeCon ?
+00:21:44	Schlomo Schapiro:	I'd like to suggest to add another category for evaluation, or maybe use it to rank the talks: How much do the talks reflect our GitOps principles?
+00:24:41	Philippe Ensarguet:	we should be cautious about the number of proposals up to now ;-)
+00:29:10	Roberth Strand:	We from the north is known for swearing, kick ass doesn't make the list at all :P
+00:30:25	Philippe Ensarguet:	and do we have an idea of number of required talks to fuel the day?
+00:31:22	Christian Hernandez:	++ @schlomo!
+00:32:12	Roberth Strand:	I'm ready to vote :P
+00:32:22	Scott - CNCF GitOps Working Group:	+1
+00:34:21	Scott - CNCF GitOps Working Group:	I was thinking the same
+00:36:07	Scott - CNCF GitOps Working Group:	+1 to cell comments
+00:37:35	Chris Short:	Please change "Total" to Average
+00:41:46	Philippe Ensarguet:	@schlomo, it works !
+00:51:55	Scott - CNCF GitOps Working Group:	GMT?
+00:52:03	Scott - CNCF GitOps Working Group:	+1
+00:52:16	Philippe Ensarguet:	And you have a french guy ;-)
+00:56:41	Scott - CNCF GitOps Working Group:	+1
+00:56:48	Leonardo Murillo:	+1
+00:56:50	Chris Short:	+100
+00:56:50	Philippe Ensarguet:	@cornelia, great idea!
+00:56:52	Roberth Strand:	+2
+00:58:45	Cornelia Davis:	Thank you Roberth :-)
+01:01:42	Cornelia Davis:	I need to run folks. Thank you all so much for the work here!
+01:01:50	Roberth Strand:	Bye
+01:01:58	Philippe Ensarguet:	Do we have to decide for a special action to boost the audience on the CFP ?

--- a/meetings/committee-gitopscon/2021-04-15-chat.txt
+++ b/meetings/committee-gitopscon/2021-04-15-chat.txt
@@ -1,0 +1,6 @@
+00:08:16	Christian Hernandez:	https://docs.google.com/document/d/17Ox2c7YWXDKmUq83R1hQpt6g2YOlSg07r3uv7JUjgu8/edit#heading=h.mfx9iz8tgw9j
+00:23:28	Chris Short:	https://docs.google.com/document/d/14eHgAjFvbjRUMDl6uHX3bb1DQJvxRu6ddQPFX-e-wfY/edit#heading=h.o4t0j0rs3amd
+00:41:54	CNCF GitOps Working Group:	PS I added notes here because I wasn’t sure where to put them. We can merge afterwards https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.kr2ebmvnmiq7
+00:42:16	CNCF GitOps Working Group:	I agree
+00:48:24	Tamao:	Sorry I have to drop off. Thanks!
+00:52:44	Sara E. Davila:	I need to drop - thanks for letting me join :)

--- a/meetings/committee-gitopscon/2021-04-20-chat.txt
+++ b/meetings/committee-gitopscon/2021-04-20-chat.txt
@@ -1,0 +1,31 @@
+00:06:10	Scott:	We’re now recording
+00:06:14	Leonardo Murillo:	https://docs.google.com/spreadsheets/d/13r31KwCDjBXTrtsq-3ddwT2qFLnQEEannOO7cVlFXrM/edit#gid=322767999
+00:08:31	Cornelia Davis:	Hello all. I am bandwidth challenged so will leave my camera off.
+00:08:31	Scott:	Agenda doc for this meeting: https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.6b4oie86y8kg
+00:08:46	Scott:	Dan moderating. We have not yet moved to hand raising, but may want to
+00:10:10	Cornelia Davis:	Also, I am only available the first hour of this call.
+00:10:25	Chris Short:	Yeah, I have to drop the last thirty minutes
+00:11:25	Scott:	@Chris is there anything you want to make sure to address before you have to drop?
+00:13:19	Leonardo Murillo:	https://docs.google.com/spreadsheets/d/13r31KwCDjBXTrtsq-3ddwT2qFLnQEEannOO7cVlFXrM/edit
+00:13:53	Chris Short:	I'll need to know the flow, but yeah, I should build out an outline for hosting
+00:15:34	Scott:	I will be doing reviews today as well
+00:19:03	Scott:	Ah right
+00:19:44	Scott:	Awesome
+00:20:45	Chris Short:	Christian, how did you know which talks were Red Hatters?
+00:21:12	Christian Hernandez:	It's in the other tab
+00:21:18	Christian Hernandez:	"Form Responses"
+00:21:25	Philippe Ensarguet:	on Form response tab
+00:21:41	Chris Short:	ha... scroll down, dunce
+00:23:28	Scott:	For sure
+00:24:30	Philippe Ensarguet:	from the trenches ;-)
+00:25:02	Roberth Strand:	Good name
+00:25:04	Christian Hernandez:	Yes Philippe!
+00:25:10	Christian Hernandez:	Tres bien
+00:30:34	Schlomo Schapiro:	https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/colocated-events/#fluentcon-cloud-native-logging-day
+00:31:47	Chris Short:	https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/colocated-events/#gitops-con
+00:31:47	Roberth Strand:	Timezones are great
+00:37:19	Philippe Ensarguet:	Sonja said that we are close to 1,600 attendees
+00:37:42	Cornelia Davis:	WOW!
+00:47:56	Philippe Ensarguet:	We only have 7 Lightning talks before final cut
+00:48:28	Scott:	When I said “good” what I meant was, we should at least make sure they’re all relevant
+00:56:55	Scott:	https://doodle.com/poll/n59y5uyh2ustenwy

--- a/meetings/committee-principles/2021-03-29-chat.txt
+++ b/meetings/committee-principles/2021-03-29-chat.txt
@@ -1,0 +1,30 @@
+00:13:14	Scott - CNCF GitOps Working Group:	https://hackmd.io/arwvV8NUQX683uBM3HzyNQ
+00:22:22	Scott - CNCF GitOps Working Group:	Glossary: https://github.com/gitops-working-group/gitops-working-group/pull/48/files#diff-e76bd6f4d59f7e55fe3ce2f09d5e817bd9cc6991dbe62de27aadab5e68511043
+00:24:01	Christian Hernandez:	+1 to what Leo said
+00:34:53	Scott - CNCF GitOps Working Group:	Cool Moshe, got your 👍
+00:42:34	Scott - CNCF GitOps Working Group:	S/continuous/automated/g?
+00:44:17	Toni Menzel:	I strongly favour continuous here..
+00:47:30	Scott - CNCF GitOps Working Group:	So how about s/immediately/continuously/g?
+00:48:01	Leonardo Murillo:	I lean towards Brice's stance
+00:48:26	Christian Hernandez:	I'm also leaning towards what Brice is saying
+00:48:46	Scott - CNCF GitOps Working Group:	GitOps is predicated on the idea that things will fail, and there should be automatic attempts to reconcile your actual state
+00:52:01	Toni Menzel:	I think it is important to distinguish GitOps and what we had in "plain" CI. The continuous reconciliation is an important detail.
+00:52:18	Roberth Strand:	I agree
+00:52:57	Scott - CNCF GitOps Working Group:	Next up me, 1 minute
+00:55:56	Christian Hernandez:	Distilling
+00:56:16	Roberth Strand:	Principle of state reconciliation, +1
+00:56:30	Lothar Schulz:	+1
+01:00:52	Scott - CNCF GitOps Working Group:	Or what if the event triggered action doesn’t succeed initially?
+01:01:32	Scott - CNCF GitOps Working Group:	s/continuous/periodic?
+01:02:00	Scott - CNCF GitOps Working Group:	Or certainly other IaaC
+01:04:18	Scott - CNCF GitOps Working Group:	“Continuous” means “unbroken, without interruption”
+01:04:33	Scott - CNCF GitOps Working Group:	And I agree with you all here, that is not 100% correct
+01:05:00	Leonardo Murillo:	I think automated is a good first step
+01:05:07	Scott - CNCF GitOps Working Group:	Continuous does NOT imply immediacy
+01:05:13	Scott - CNCF GitOps Working Group:	+1 automated
+01:06:20	Scott - CNCF GitOps Working Group:	Also, Continuous Delivery has a very specific idea of “Continuous”
+01:08:06	Toni Menzel:	+1 on Roberth
+01:08:20	Scott - CNCF GitOps Working Group:	Sorry Robert what was your wording suggestion?
+01:08:26	Scott - CNCF GitOps Working Group:	Let’s note that
+01:08:35	Roberth Strand:	The principle of state reconciliation
+01:12:58	Roberth Strand:	23:08 here ;)

--- a/meetings/committee-principles/2021-04-05-chat.txt
+++ b/meetings/committee-principles/2021-04-05-chat.txt
@@ -1,0 +1,54 @@
+00:09:26	Carlos Santana:	I do
+00:09:38	Carlos Santana:	At 2x
+00:09:56	Carlos Santana:	timezone
+00:10:58	Carlos Santana:	Is this the chat or there is a Slack channel you usually use ?
+00:11:20	Roberth Strand:	We usually use the Slack channel for general chatting
+00:15:35	Carlos Santana:	yes
+00:18:05	Carlos Santana:	Automatic?
+00:18:42	Carlos Santana:	Oh I see the “automated” actions afterwards.
+00:21:53	Scott - CNCF GitOps Working Group:	Next is Brice, then Timothy, Cornelia
+00:21:53	Brice Fernandes:	“The principle of reconciliation” would be sufficient - Details can be in the details
+00:22:58	Jesse Butler:	I don’t want to jump the hand queue, but what’s protocol for response?
+00:23:41	Roberth Strand:	I guess just bust in :P
+00:24:28	Schlomo Schapiro:	👍to a shorter title like Brice suggested. For me, "reconciliation" emphasizes the goal and I start to think that the details of continuous vs. regularly and the remediation details (immediate, eventually) are actually totally irrelevant - on the level of the principles
+00:26:06	Roberth Strand:	Same reasoning that I had the last meeting, when we discussed this. I think that having the principle of state reconciliation is more than enough as a title for the idea we're trying to get across
+00:26:20	Jesse Butler:	I re-raised, yep
+00:26:59	Scott - CNCF GitOps Working Group:	Next Cornelia, Jesse, Schlomo (going in order of hands raised)
+00:28:32	Jesse Butler:	+1 in all parts.
+00:28:37	Leonardo Murillo:	+1
+00:28:44	Roberth Strand:	Good point
+00:30:45	Roberth Strand:	Again, good point :)
+00:31:39	Scott - CNCF GitOps Working Group:	I’d like to suggest we do so in the notes
+00:35:05	Jesse Butler:	:nod:
+00:36:12	Brice Fernandes:	seconded
+00:38:24	Scott - CNCF GitOps Working Group:	thirded
+00:42:52	Scott - CNCF GitOps Working Group:	What about “s/differ/differ for any reason/g”
+00:46:57	Leonardo Murillo:	I think its redundant
+00:48:16	Roberth Strand:	Thirderded
+00:48:29	Cornelia Davis:	I agree that from a “mathematical” perspective that it’s unnecessary, but I do think it is helpful particularly for new folks.
+00:50:09	Schlomo Schapiro:	Yes, this is not a math exercise but rather should explain what we mean with as little potential for misunderstandings as possible
+00:52:44	Brice Fernandes:	I think taken/attempted/etc… is quite a small point that should be explored in the notes/explanation. It’s quite subtle for a first reading. I defer to the consensus for what that word choice is.
+00:53:46	Brice Fernandes:	We can deal explicitly with actions success/failur in the explanatory notes, with maybe a state diagram.
+00:53:53	Roberth Strand:	The principle should still stand, even if the attempt fail.
+00:54:07	Carlos Santana:	That was the part of “loop” that was removed
+00:54:30	Schlomo Schapiro:	For me "continuous" implies enough of a "loop" like behavior, IMHO
+00:55:17	Roberth Strand:	I agree with the wording. Initiated makes sense.
+00:55:23	Cornelia Davis:	You are right Schlomo! I really like “initiated”
+00:55:45	Carlos Santana:	I think the conversation are good, but as things get discussed the good points can be categorized as “part that helps define the principle” vs “not part of the principle, but a implementation detail following a principle”
+00:55:51	Brice Fernandes:	+1 on initiated>taken>attempted
+00:57:04	Schlomo Schapiro:	For me the automated decision to take action is the core of the principle, everything else is then implementation details.
+00:57:35	Leonardo Murillo:	+1 on initiated
+00:58:28	Roberth Strand:	Let's talk about #4 :P
+01:01:16	Carlos Santana:	Another thing to keep in mind is that these principles are GitOps, that how are the principles are different from XOps, like kubernetes or an operator reconciliation between desire state in a store/db (ie etcd) and current state, and initialing actions.
+01:02:12	Scott - CNCF GitOps Working Group:	💯
+01:02:37	Carlos Santana:	At first glance when I saw these principles for the first time, I thought it was describing k8s of using reconciliation and using delcaritve, the only difference is the store is git vs. etcd or sql (k3s)
+01:03:35	Schlomo Schapiro:	p4: preferred suggests for me a choice, which I'd like to veto
+01:03:43	Leonardo Murillo:	Have a hard stop for another meeting, gotta drop
+01:03:49	Leonardo Murillo:	great conversation everybody!
+01:03:55	Scott - CNCF GitOps Working Group:	Thanks Leonardo!
+01:04:10	Carlos Santana:	Instead of the human dealing with tube api to write to etcd, the human is dealing with git, that then another thing takes into etcddb, k8s controllers takes care of reconciliation, I’m new to the group so sorry for my ignorance, I will have better PoV after spending more time with they crowd
+01:04:24	Brice Fernandes:	Bye Leonardo!
+01:04:26	Cornelia Davis:	I need to jump.
+01:04:47	Roberth Strand:	I think we should follow this up in the next meeting
+01:04:56	Jesse Butler:	Good progress!
+01:05:14	Roberth Strand:	Cheers, see you next time

--- a/meetings/committee-principles/2021-04-14-chat.txt
+++ b/meetings/committee-principles/2021-04-14-chat.txt
@@ -1,0 +1,63 @@
+16:03:04 From Scott - CNCF GitOps Working Group to Everyone : https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.7wmerton06if
+16:03:15 From Scott - CNCF GitOps Working Group to Everyone : https://hackmd.io/arwvV8NUQX683uBM3HzyNQ
+16:09:03 From Schlomo Schapiro to Everyone : Moshe, I am not sure there is a conflict. The state reconciliation is continuous and the freeze is part of the declared state for me. The mechanism will still continuously check for discrepancies and then DECIDE to not act because the desired state has a freeze
+16:09:39 From Dan Garfield to Everyone : Yeah I think I agree. Like if you have a freeze window for an hour on Sunday evenings it wouldn’t be continuous? Seems pretty continuous.
+16:10:03 From Roberth Strand to Everyone : +1 towards what Schlomo says
+16:10:04 From Leonardo Murillo to Everyone : the freeze condition becomes part of the desired state correct
+16:10:28 From Leonardo Murillo to Everyone : and the freeze condition should be declarative as well
+16:11:07 From Christian Hernandez to Everyone : +1 leo
+16:11:30 From Dan Garfield to Everyone : Yeah, in big orgs where you have commits having every few minutes, it would actually be disruptive to sync those all right away. You set windows during which syncs will occur, hourly, daily, whatever.
+16:12:21 From Shoubhik Bose to Everyone : This is a really good conversation, thanks Moshe for bringing up this point.
+16:12:51 From Schlomo Schapiro to Everyone : Just a thought for later: I'd prefer to think the principles in a "clean room" and not mold them to fit the existing tools that happen to fly the "GitOps flag". Maybe in the end we will provide input for the future development of tools
+16:12:53 From Roberth Strand to Everyone : Are we defining the principals that the GitOps process should strive to, or try to cater to every tool?
+16:15:27 From Schlomo Schapiro to Everyone : Brice, if the change freeze is implemented via not pushing to master, then where would you put that info in a declarative way?
+16:16:20 From Schlomo Schapiro to Everyone : For me it is important that GitOps is "a" "clean & consistent" way - consistent with itself
+16:22:36 From Scott - CNCF GitOps Working Group to Everyone : I don’t believe anything has been said yet to limit desired state to a single repository
+16:22:57 From Christian Hernandez to Everyone : I don't think it has, no
+16:24:39 From Schlomo Schapiro to Everyone : We are discussing IMHO the question if the freeze desired state is in-band (in a Git repo) or out-of-band (in a "button" in the mechanism), which would in my eyes make it not part of the desired state because principle 1 requires the entire desired state to be manage declaratively
+16:25:24 From Schlomo Schapiro to Everyone : also, for the decision to have a freeze or to release the freeze, how do you get Git-style auditing and tracing (4-eyes-principle ...)
+16:27:02 From Christian Hernandez to Everyone : +1 Schlomo
+16:27:47 From Leonardo Murillo to Everyone : continuous =! dense != sequential
+16:28:01 From Brice Fernandes to Everyone : There is a clear way to do proper GitOps Canaries.
+16:28:20 From Scott - CNCF GitOps Working Group to Everyone : I believe we may be bike shedding here. We are debating connotations of a single, industry standard word
+16:28:20 From Brice Fernandes to Everyone : It does not involve having floating state
+16:28:44 From Roberth Strand to Everyone : Isn't the point that we're doing state reconciliation, and if we say that our desired state is not to merge an update in code, it's still continuous?
+16:28:59 From Dan Garfield to Everyone : Brice shoot me a link if you have one, I’d be interested to see if I’m missing something.
+16:32:30 From Scott - CNCF GitOps Working Group to Everyone : There is also a “break glass” clause in the Pull Request
+16:32:37 From Dan Garfield to Everyone : Great point, the reconcilers are doing the thing continuously, how they’re handling the rollout and in what time period isn’t required here.
+16:33:25 From Brice Fernandes to Everyone : *Desired* state.
+16:33:42 From Brice Fernandes to Everyone : The only way to have the *actual* state of a system is to observe the syetm
+16:35:22 From Roberth Strand to Everyone : 100% agree with that point
+16:35:25 From Christian Hernandez to Everyone : +1000000
+16:37:30 From Dan Garfield to Everyone : This is like a Zeno’s paradox thing. Continuous means without interruption and if the reconciler is only polling 1000 times a second that means there are 1000 interruptions in the continuous process per second so it’s no longer continuous? At a certain point the “interruption” is small that does it matter?
+16:38:16 From Christian Hernandez to Everyone : We'll never pass the turtle
+16:38:38 From Leonardo Murillo to Everyone : out of band manipulations would actually breach the 4th principle actually
+16:38:47 From Brice Fernandes to Everyone : Re Loop - Absolutely
+16:39:59 From Scott - CNCF GitOps Working Group to Everyone : Do we not like appending “according to your configured rules”
+16:40:24 From Schlomo Schapiro to Everyone : Sorry, since there is no direct click button for the hand I sometimes forget to lower the hand
+16:40:33 From Scott - CNCF GitOps Working Group to Schlomo Schapiro(Direct Message) : All good :)
+16:42:53 From Leonardo Murillo to Everyone : agreed, principles should define direction and aspiration,not expect to be a reflection of the current implementation and maturity in the ecosystem
+16:42:59 From Christian Hernandez to Everyone : That's be a good CFP :)
+16:43:08 From Christian Hernandez to Everyone : "GitOps incedent management"
+16:44:14 From Roberth Strand to Everyone : I strongly believe that contineous still applies, even with freeze changes. A freeze change would imply that our desired state is not to follow any code changes, at this particular moment.
+16:46:06 From Dan Garfield to Everyone : I agree Roberth
+16:46:55 From Christian Hernandez to Everyone : +1 Roberth. And as Leo said, freeze is part of your state.
+16:52:13 From Christian Hernandez to Everyone : "The principle of state reconciliation"
+
+"Software agents compare a system’s Actual State to its Desired State. If the actual and desired states differ for any reason, actions to reconcile them are initiated."
+16:52:34 From Scott - CNCF GitOps Working Group to Everyone : The problem is we did that last week, and nearly EVERYONE found this disagreeable.
+16:52:44 From Roberth Strand to Everyone : What Scott said
+16:53:02 From Schlomo Schapiro to Everyone : +1 for consensus, if we can't reach it then I'd prefer to release a 0.2 version of the principles with a list of topics that lack consensus. The goal would be to release the 98% of good stuff that we already produced and allow further discussions, even by other people, about the disagreements.
+16:53:19 From Dan Garfield to Everyone : Agreed Schlomo
+16:54:06 From Schlomo Schapiro to Everyone : For me the continuous aspect of GitOps, as in the train never stops ("Snowpiercer"), is quite essential. But I'll be very happy to shelf that question for later
+16:54:49 From Dan Garfield to Everyone : @Schlomo do you think having windows violates that?
+16:55:36 From Schlomo Schapiro to Everyone : I don't know about the windows, I think we would need to talk a bit more about what that exactly means, I only have a very fuzzy image of this concept.
+16:55:55 From Roberth Strand to Everyone : I rather keep it and highlight it, in the initial version, as something to come back to
+16:57:32 From Christian Hernandez to Everyone : Roberth is at a bar :)
+16:57:58 From Roberth Strand to Everyone : Moe's the best
+16:58:02 From Brice Fernandes to Everyone : A Caveats section would be useful addition to whatever artefact we release.
+16:59:10 From Roberth Strand to Everyone : I think loop is worse word to use, and even sounds more continuous than continuous.
+16:59:25 From Dan Garfield to Everyone : Having a document that has notes about areas of potential dissent and disagreement is ok with me.
+17:01:30 From Nate Taber to Everyone : Have to drop thanks all
+17:01:47 From Roberth Strand to Everyone : Yes, Sir
+17:01:51 From Dan Garfield to Everyone : Ditto, sounds good.

--- a/meetings/monthly/2020-12-10-chat.txt
+++ b/meetings/monthly/2020-12-10-chat.txt
@@ -1,0 +1,79 @@
+00:20:09	Dan:	hey everyone, sorry for being late, had a meeting run long
+00:21:47	Shoubhik Bose:	Hey Dan
+00:25:38	Scott Rigby:	Would we say that “git” in gitops is a shorthand for something like “versionable declarations of desired state for operations”?
+00:26:01	Chris Patterson:	Yes I think that is a good way to put it
+00:26:26	Chris Patterson:	For example Flux already supports Helm charts as a source and that is not necessarily a git repository
+00:26:49	Scott Rigby:	Correct. Also object storage buckets, because they _can_ be versioned.
+00:26:52	Shoubhik Bose:	Agreed. Versionable implicitly
+00:26:57	Ken:	well put!
+00:30:30	Chris Short:	+1
+00:30:36	Scott Rigby:	Should we consider a hand raising process, now that we have almost 50 people on the call?
+00:30:43	Leonardo Murillo:	+1 ^
+00:30:46	Engin Diri:	+1
+00:30:50	Waqas Ali:	+1
+00:32:33	Ed Lee:	+1
+00:33:10	Christian Hernandez:	I think it's more of a "yes, and"
+00:33:20	isaac@armory.io:	I joined late. will this recording be shared?
+00:33:59	Chris Patterson:	We have admission hooks etc that will alter resources as they deploy
+00:34:09	Scott Rigby:	Regarding the “does A or B project qualify as gitops?” question, I wonder if we may consider this less as a binary and more as a progressive definition. More like “does A or B project specifically meet for X, Y or Z gitops standards?”
+00:34:16	Dan:	@Isaac yes
+00:34:27	Dan:	I’m also keeping meeting notes in the working group doc.
+00:34:39	Shoubhik Bose:	Yes this has to be a progressive definition, I feel.
+00:34:45	Shoubhik Bose:	@Scott.
+00:34:55	Christian Hernandez:	+1 Scott
+00:35:04	Ed Lee:	+1 Scott
+00:35:42	Engin Diri:	@Chris: Mutating admission hooks are very bad on gitops
+00:35:51	Dan:	100% progressive definition
+00:36:20	Engin Diri:	the cluster differs from the declaration
+00:36:49	Chris Patterson:	@Engin I don’t disagree but they are a fact of life we need to consider
+00:36:52	Christian Hernandez:	"git" in "gitops" is tech debt 😅
+00:36:54	Shoubhik Bose:	Mutating admission hooks: This is something that the group should discuss and note down observations/good practices
+00:37:11	Engin Diri:	@Chris: you are 100% right
+00:37:12	Ed Lee:	+1 Shoubhik
+00:37:17	Chris Patterson:	And in many cases they are used to enforce policy and doing that upstream can be extremely complex if not impossible
+00:37:18	Karthik:	+1 Shoubik
+00:37:33	Chris Patterson:	+1 Shoubik
+00:38:04	Shoubhik Bose:	Mutating admission web hooks are annoying for Gitoops  :( but they provide value when not overused :)
+00:38:09	Shoubhik Bose:	*GitOps
+00:38:26	Engin Diri:	i use kyverno, ad i check the validations also in to the repo to atleast give the persons the chance to know would go on  in the cluster
+00:39:37	Daniel Lizio-Katzen:	https://cloud-native.slack.com/archives/C01G9DEE88M
+00:40:00	Tim Pouyer:	+1 to agenda for future meetings
+00:40:01	Omer Kahani:	The chat can be saved in newer version of Zoom
+00:41:34	Chris Patterson:	I just saved the current state
+00:43:03	Scott Rigby:	👍
+00:43:17	Leonardo Murillo:	I keep thinking about 12 factors as a good example to follow, a set of recommendations, there even is some overlap
+00:43:38	Leonardo Murillo:	seems like a lot of the difference is in terms of delivery or reconciliation
+00:43:45	Scott Rigby:	Thanks Dan 💯
+00:43:47	Chris Short:	Gotta drop. Great discussion.
+00:43:57	Scott Rigby:	Thanks Chris, see you
+00:45:21	Omer Kahani:	Coming from the Operator WG, I think it will be interesting to combine GitOps with the general case of operator. Something like gitops is using version controlled storage with an operator
+00:46:29	Fahad Arshad:	Hmm  so can an image registry or even s3 bucket be substituted for git in gitops?
+00:46:43	Chris Patterson:	@Fahad yes
+00:47:48	Ken:	there is a project named kubefed which is a combo of operators and multi cluster management
+00:48:18	Ken:	not meaning to be prescriptive just providing awareness
+00:48:30	Scott Rigby:	Right. Git and k8s are just currently considered superior tools for versioned declaration and reconciliation
+00:50:13	Dan:	100% Scott
+00:51:55	Engin Diri:	the word is burned… as we call it in German
+00:52:12	Scott Rigby:	Maybe it should be a “Declaration of GitOps” lol
+00:52:16	Gurney Buchanan:	As a young person - I learned it in college!
+00:52:43	Leonardo Murillo:	political?
+00:52:53	Scott Rigby:	Dogmatic, etc.
+00:53:13	Engin Diri:	Pillars of GitOps
+00:54:00	Christian Hernandez:	Declaration
+00:54:16	Christian Hernandez:	it fits as "declarative infrastructure"
+00:54:28	Christian Hernandez:	I don't mind Manifesto, however
+00:54:37	Dan:	Declaration of GitOps lol, that's great Christian
+00:54:56	Fahad Arshad:	Well Architected GitOps
+00:54:58	Justin Cormack:	I could reconcile myself to declaration...
+00:56:14	Dan:	oh Scott you said it too
+01:00:05	Scott Rigby:	🤚 can’t raise hand as co-host but here’s my +1
+01:00:26	Dan:	@Scott you might be on old zoom
+01:00:27	Daniel Lizio-Katzen:	https://cloud-native.slack.com/archives/C01G9DEE88M
+01:00:35	Dan:	I can mark yes/no
+01:01:17	Daniel Lizio-Katzen:	https://slack.cncf.io/
+01:03:44	John Duimovich:	Thanks all, great discussion
+01:03:52	Omer Kahani:	Thank
+01:03:56	Jann:	Thank you everyone
+01:04:04	Dan:	Lets keep it going in slack, keep building these connections, great comments from everyone!
+01:04:16	Steve Buchanan:	Thanks all!
+01:04:17	Engin Diri:	was very cool! looking forward for the next session / steps

--- a/meetings/monthly/2021-01-14-chat.txt
+++ b/meetings/monthly/2021-01-14-chat.txt
@@ -1,0 +1,17 @@
+00:23:59	Tim Pouyer:	I had created an issue for a GitOps Working Group product name in a similar vein to "12 factor apps" to use "GitOps Commitments" which I think is a fun name https://github.com/gitops-working-group/gitops-working-group/issues/8
+00:24:26	Engin Diri:	yeah i saw this one!
+00:30:21	Omer Kahani:	Yes for that! We need feedback in gitops
+00:33:02	Engin Diri:	is this not part of the e.g kubernetes?
+00:34:46	Ed Lee:	verifiable target state
+00:38:24	Dan Garfield:	Tin reconciler
+00:38:33	Dan Garfield:	Tiny reconciler*
+00:39:04	Jesse Butler:	Is there a link to agenda doc(s)?
+00:39:19	Mya:	https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit?usp=sharing
+00:39:56	Engin Diri:	reference architecture would be nice. People sstruggle (at least at my place) the get ther head around
+00:40:09	Engin Diri:	their*
+00:42:54	Kara de la Marck:	https://github.com/cdfoundation/sig-interoperability/blob/master/docs/vocabulary.md
+00:43:51	jstrachan:	a way to map Pipelines => GitOps is the Pipeline can create a Pul Request on the Git repository
+01:00:34	Kara de la Marck:	Got to drop for another meeting. Thank you all very much for an interesting meeting!
+01:00:51	Shoubhik Bose:	Got to drop, great discussion!
+01:02:25	Leonardo Murillo:	gotta drop as well, great convo indeed! thanks everybody
+01:03:06	Dan Garfield:	thanks!

--- a/meetings/monthly/2021-02-11-chat.txt
+++ b/meetings/monthly/2021-02-11-chat.txt
@@ -1,0 +1,49 @@
+00:09:38	Brice Fernandes:	https://github.com/gitops-working-group/gitops-working-group/pull/48
+00:10:11	Nate Taber:	Thanks Brice
+00:11:27	Engin Diri:	Looks really nice! Good Work, Brice!
+00:14:00	Scott Rigby:	Woot woop
+00:16:22	Daniel Lizio-Katzen:	­https://cloud-native.slack.com/archives/C01G9DEE88M
+00:17:31	Schlomo Schapiro:	Can you please repost the meetings Doc? I don't see the old chat after rejoining from my desktop
+00:17:57	Engin Diri:	https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#
+00:23:53	Scott Rigby:	Well said 👏
+00:25:58	Waldemar:	What are the requirements for the co-chairs and is it suitable new people to this working group?
+00:28:16	Waldemar:	Alright thanks!
+00:30:14	Waldemar:	Makes perfectly sense, thanks.
+00:30:55	Cornelia Davis:	I’m still here. Just going to get my tea :-)
+00:32:59	Scott Rigby:	Thanks Brice, was just going to say that
+00:34:12	Daniel Lizio-Katzen:	Here are the notes for today if you don't have the link: https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#
+00:46:31	Schlomo Schapiro:	Since I don't know about the previous discussion I don't understand what's the problem with calling it "GitOps Principles" or who objects to that term.
+00:46:52	Schlomo Schapiro:	Like, GitOps Principles sounds perfectly appropriate to me :-)
+00:49:09	Scott Rigby:	Correct Chris
+00:49:19	Gurney Buchanan:	+1
+00:49:21	Scott Rigby:	+1
+00:49:23	Cornelia Davis:	+1
+00:49:24	Leonardo Murillo:	+1
+00:49:26	Waldemar:	+1
+00:49:29	Engin Diri:	+1
+00:50:52	Chris Patterson:	We are doing the same with docker distribution as well
+00:50:53	Jeff Krupinski:	+1
+00:51:01	Chris Patterson:	Just trying to get things moving
+00:51:32	Brice Fernandes:	https://github.com/gitops-working-group/gitops-working-group/issues/49
+00:54:03	Scott Rigby:	+1
+00:56:49	Brice Fernandes:	+1 on the sponsoring orgs
+00:56:58	Scott Rigby:	Cornelia, I just made a gh discussion for this https://github.com/gitops-working-group/gitops-working-group/discussions/50
+00:57:08	Leonardo Murillo:	+1 I can provide a sponsoring org
+00:58:57	Cornelia Davis:	Thank you Scott.
+00:59:13	Leonardo Murillo:	gotta drop, thanks everybody
+00:59:32	Gurney Buchanan:	Have to drop - thanks folks!
+01:00:15	Scott Rigby:	That’s what I was thinking
+01:00:35	Brice Fernandes:	+1 for "GitOps Initiative”
+01:02:48	Jesse Butler:	And sorry, my camera is broken-ish. See you all next time I hope :)
+01:03:24	Jesse Butler:	I need to drop , thanks all chat again soon!
+01:04:01	Chris Sanders:	+1 for "GitOps Initiative”
+01:04:18	Chris Patterson:	Have to drop
+01:04:23	Dan Garfield:	Thanks Crhis
+01:04:26	Dan Garfield:	Chris*
+01:05:10	Scott Rigby:	Moshe, I love the idea of dogfooding. However, moving all our discussions to just within git is a very cumbersome way to actually discuss things. For example we can’t zoom in git either. But when the discussion is answered we can commit it to git
+01:05:55	Toni Menzel:	zoom in git.. good point ;)
+01:06:03	Chris Sanders:	Git = single source of truth :-)
+01:06:28	Waldemar:	Well said Brice. i agree.
+01:07:47	Brice Fernandes:	Worth noting is that we’re not really operating software as a working group.
+01:09:48	Scott Rigby:	Brice yes, and nothing to automatically “reconcile”
+01:09:51	Scott Rigby:	Bye!

--- a/meetings/monthly/2021-03-11-chat.txt
+++ b/meetings/monthly/2021-03-11-chat.txt
@@ -1,0 +1,65 @@
+00:08:58	Schlomo Schapiro:	Do you have any idea about the expected time commitment? 1 day per week? Less? More?
+00:09:31	Engin Diri:	why not
+00:09:33	Omer Kahani:	yes
+00:09:38	Christian Hernandez:	+1
+00:09:54	Daniel Lizio-Katzen:	Meeting notes will be tracked here: https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.w91ueqcmi7nzPlease add yourself to the attendees list.
+00:11:28	Engin Diri:	+1
+00:11:32	Dax McDonald:	:+1:
+00:11:39	Roberth Strand:	I agree as well
+00:12:02	Schlomo Schapiro:	Probably other people will also need to check with their team/boss before saying anything about such a time comittment...
+00:12:14	CNCF Flux:	Sorry for the delay folks
+00:12:38	Daniel Lizio-Katzen:	For the new joiners: Meeting notes will be tracked here: https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.w91ueqcmi7nzPlease add yourself to the attendees list.
+00:14:49	Christian Hernandez:	Good point Leonardo +1
+00:15:02	Schlomo Schapiro:	Do we raise hands or just jump in?
+00:15:17	Scott:	Let’s raise hands
+00:18:14	Christian Hernandez:	I think that would happen no matter WHAT logo we choose
+00:20:07	Daniel Lizio-Katzen:	Meeting notes will be tracked here: https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.w91ueqcmi7nzPlease add yourself to the attendees list.
+00:20:46	Schlomo Schapiro:	Otherwise +1 for Leonardos point about the logo being fairly specific to what it should represent. We can alsways find a more generic logo later on
+00:20:59	Scott:	https://github.com/gitops-working-group/gitops-working-group/discussions/64
+00:24:35	Engin Diri:	The Logo topic is so not the first to solve :) People never asked me about a gitops logo :)
+00:24:50	Engin Diri:	the know the ArgoCD or FluxCD logo more
+00:24:57	Engin Diri:	they*
+00:26:20	Schlomo Schapiro:	I actually meant that I'd like to agree upon "criteria for done" for the logo choosing process before starting it. Otherwise we'll have a never-ending discussion on the logo while this is a minor item in the big picture.
+00:27:04	Scott:	Schlomo gotcha. Can you clarify this in the notes google doc?
+00:27:23	Schlomo Schapiro:	About the logo and which text to put there: Why not have it all? We can have the same double-arrow image with different text pieces: One for the working group, one for the initiative, one for the project, one for the certification and so on.
+00:27:29	Scott:	Absolutely Henrik, these are definitely separate
+00:28:03	Christian Hernandez:	+1 Toni
+00:28:26	Dax McDonald:	+1 Toni
+00:28:29	Scott:	Toni no it has not been decided. It will be there, please participate  https://github.com/gitops-working-group/gitops-working-group/discussions/64
+00:29:17	CNCF GitOps Working Group:	Henrik, is your hand up again?
+00:29:32	CNCF GitOps Working Group:	So I know whether to come back to you.
+00:29:37	Roberth Strand:	https://github.com/gitops-working-group/gitops-working-group/pull/48
+00:30:07	Henrik Blixt:	No, it was up still :)
+00:30:52	Leonardo Murillo:	self-resolving priorities, I want some of those :P
+00:35:54	Scott:	Sounds fair. The goal of the co-working session is for 0.1.0
+00:36:31	Roberth Strand:	Really hard for a newcomer like me to actually read it, and understand it fully.
+00:38:41	CNCF GitOps Working Group:	+1 on working in non-main branch and the group can decide when they want to merge back into main.
+00:39:23	CNCF GitOps Working Group:	That is a way to “publish only what we agree upon”
+00:40:36	Schlomo Schapiro:	What could happen worst case? Somebody goes and sells a 0.1.0 version of our principles? Good luck to them
+00:40:52	Scott:	Toni, good question. My personal criteria is that we should agree on the principles IN GENERAL
+00:41:32	Scott:	We are currently using branching
+00:41:45	Omer Kahani:	If it’s in the main branch it’s in production… if it’s in main it’s agreed on
+00:41:49	Scott:	Yes the branch is a pull
+00:42:02	Scott:	Omer correct 👍
+00:42:21	Dax McDonald:	+1 to a WIP version, “staging” branch
+00:43:20	Scott:	Currently the branch name is “proposed-principles"
+00:44:11	Scott:	https://github.com/gitops-working-group/gitops-working-group/pull/48#issuecomment-796176375
+00:44:47	Schlomo Schapiro:	We should choose the date/time on Slack and invite people via the GitHub PR, too.
+00:45:26	Scott:	Moshe I’m inclined to agree
+00:45:31	Leonardo Murillo:	+1
+00:45:32	Engin Diri:	+1
+00:45:40	Toni Menzel:	+1
+00:46:07	Roberth Strand:	Having a sync session would give people the chance to discuss things, so that one doesn't misunderstand things through threads.
+00:49:37	Scott:	I made an “Action items” section of the meeting notes doc, and added this as well Cornelia
+00:52:18	Jeff Krupinski:	+1 on the website
+00:55:17	Toni Menzel:	Can't we create the channel for the website ourselves? I could do that now
+00:56:00	Leonardo Murillo:	huh I never tried, I would have thought it would be tighter controlled
+00:56:19	Scott:	We can not create CNCF channels ourselves
+00:56:27	Engin Diri:	not this year :D
+00:56:33	Toni Menzel:	It now exists
+00:57:15	Leonardo Murillo:	thnx, joined
+00:57:48	Dax McDonald:	I used the CNCF calendar
+00:58:01	Jeff Krupinski:	+1 there too
+00:58:19	Jeff Krupinski:	For calendar...
+00:59:10	Omer Kahani:	thanks
+00:59:14	Schlomo Schapiro:	Thanks a lot everybody and good seeing you all!

--- a/meetings/monthly/2021-04-15-chat.txt
+++ b/meetings/monthly/2021-04-15-chat.txt
@@ -1,0 +1,30 @@
+00:07:32	Scott - CNCF GitOps Working Group:	https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.zekmcm7llerh
+00:08:04	Scott - CNCF GitOps Working Group:	https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.zekmcm7llerh
+00:10:30	Scott - CNCF GitOps Working Group:	https://github.com/gitops-working-group/gitops-working-group/discussions/123
+00:12:10	Dan Garfield:	https://github.com/gitops-working-group/gitops-working-group/issues/113
+00:13:14	Scott - CNCF GitOps Working Group:	👏
+00:14:53	Christian Hernandez:	👏
+00:15:02	Scott - CNCF GitOps Working Group:	That makes sense 🙂
+00:15:09	Tracy Miranda:	https://events.linuxfoundation.org/gitops-summit/
+00:15:09	Ole Lensmar:	Hi all - sorry I joined late - had the wrong zoom… I’m from the Ambassador Labs team…
+00:15:26	Scott - CNCF GitOps Working Group:	Hi Ole 👋
+00:15:33	Christian Hernandez:	Love the background Lloyd!
+00:16:33	Lloyd Chang:	Thank you!
+00:25:05	Scott - CNCF GitOps Working Group:	I agree it would be nicer than having these listed only in the google doc
+00:27:59	Christian Hernandez:	The GOWG keybase chat is a lot of emojis...kind of funny that we have encrypted emojis :D
+00:31:33	Scott - CNCF GitOps Working Group:	+1
+00:34:21	Scott - CNCF GitOps Working Group:	https://github.com/gitops-working-group/gitops-working-group/discussions/129
+00:36:10	Christian Hernandez:	I take GitOps con Scott
+00:36:24	Scott - CNCF GitOps Working Group:	Christian 💯
+00:40:59	Scott - CNCF GitOps Working Group:	Alternative meeting proposal: have 2 principle draft meetings per week - one “early” (for EU) and one “late” (for US)
+00:42:55	Brice Fernandes:	I would second this @Scott.
+00:44:22	Tracy Miranda:	@Scott @Dan for cdCon BoF here's a form to submit preferences/abstract/moderators https://docs.google.com/forms/d/e/1FAIpQLSeWf6oM4plK6ow6MY3flObxeBplHnzNJ73ghPt-XNs3FyVhcQ/viewform
+00:45:02	Dan Garfield:	Added that Miranda to the notes.
+00:49:10	Scott - CNCF GitOps Working Group:	https://github.com/gitops-working-group/gitops-working-group/tree/main/assets/logos
+00:50:42	Dan Garfield:	Yeah I need to get back to the issues
+00:51:19	Brice Fernandes:	https://github.com/gitops-working-group/gitops-working-group/pull/125
+00:58:10	Scott - CNCF GitOps Working Group:	💯
+01:01:09	Jesse Butler:	Need to drop, thanks and nice to see yall!
+01:01:10	Scott - CNCF GitOps Working Group:	Good idea
+01:01:33	Dan Garfield:	Ill need to drop but I volunteered to moderate the next one, need to take some work off Scott
+01:01:49	Tracy Miranda:	thanks for having me, nice to meet you all. Gotta drop!


### PR DESCRIPTION
Resolves https://github.com/gitops-working-group/gitops-working-group/issues/71 and https://github.com/gitops-working-group/gitops-working-group/discussions/123.

I've already re-organized the meeting Google doc by committee, to make meetings easier to read, find, and know where to add the next one by browsing the table of contents.