### PR TITLE
docs(chairs): add CHAIRS file

### DIFF
--- a/CHAIRS
+++ b/CHAIRS
@@ -1,0 +1,4 @@
+Our GitOps Working group co-chairs are (in alphabetical order):
+• Dan Garfield, Codefresh 
+• Leonardo Murillo, Cloud Native Architects
+• Scott Rigby, Weaveworks


### PR DESCRIPTION
> The working group co-chairs are selected by the members of the working group and are listed in the `CHAIRS` file at the root of this git repository.
> https://github.com/gitops-working-group/gitops-working-group/blob/main/GOVERNANCE.md#working-group-co-chairs

> Congratulations to our GitOps Working Group co-chairs
> https://lists.cncf.io/g/cncf-sig-app-delivery/topic/congratulations_to_our_gitops/81810349

Relates to [Describe role of Working Group co-chairs. #86](https://github.com/gitops-working-group/gitops-working-group/pull/86)