### PR TITLE
Swap AWS and Weaveworks Maintainers, add Leonardo

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,6 +3,6 @@ The initial maintainers in alphabetical order are:
 Chris Patterson, GitHub <chrispat@github.com> (github: chrispat)
 Chris Sanders, Microsoft <chris.sanders@microsoft.com> (github: csand-msft)
 Dan Garfield, Codefresh <dan@codefresh.io> (github: todaywasawesome)
-Daniel Lizio-Katzen, Weaveworks <djlk@weave.works> (github: dj1k)
-Nathan Taber, Amazon Web Services <taber@amazon.com> (github: tabern)
-
+Scott Rigby, Weaveworks <scott@weave.works> (github: scottrigby)
+Jesse Butler, Amazon Web Services <butlerjl@amazon.com> (github: jlbutler)
+Leonardo Murillo <leonardo@murillodigital.com> (github: murillodigital)


### PR DESCRIPTION
Huge thanks to @dj1k @tabern for helping found the GitOps working group! I have spoken with both of them and they would like to pass their maintainer seats representing Weaveworks and AWS respectively to @scottrigby and @jlbutler. Likewise, since bootstrapping the GWG we have had an election adding @murillodigital as a co-chair. 

After some discussion we have decided it would be wise to have co-chairs as maintainers in general. This may change in a larger governance update but in the meantime this PR will allow us to move a bit faster since @scottrigby and @jlbutler have taken up the baton from their respective orgs to move this group forwards. Of course @dj1k and @tabern will hopefully still be involved albeit on a less frequent basis. 