### PR TITLE
Remove duplicate meetings info

### DIFF
--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,8 +1,0 @@
-# Meetings
-
-- 🗓 Working Group meetings are currently every other Wednesday at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/)
-- 👩‍💻 Join using [this Zoom link](https://zoom.us/j/93779536510?pwd=TEFzbGRzREI3MVlkZmluemVkMEhHdz09)
-- ✏️ See [Agenda and Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for next and and all previous meetings
-(hint: use the [document outline](https://support.google.com/docs/answer/6367684) to help navigate!)
-- 📼 Browse WG [YouTube playlists](https://www.youtube.com/channel/UCI6iqYuuI4gZuOCZaks5i1g/playlists) for recordings of all previous meetings
-- 📧 Additional committee meetings may be scheduled as needed, and will be announced on the [CNCF App Delivery TAG](https://github.com/cncf/tag-app-delivery) mailing list, prefixed with `[gitops-wg]`

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,54 +1,8 @@
 # Meetings
 
-The GitOps Working Group Monthly meetings are listed below, and are also on the [CNCF calendar](https://www.cncf.io/calendar/).
-
-Additionally, Working Group Committees meet weekly or as needed to complete their projects.
-These meetings are also listed below.
-
-See the [GitOps WG Meetings
-Google Doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for detailed join info, agenda, and notes for all GitOps Working Group meetings.
-Use the [document outline](https://support.google.com/docs/answer/6367684) to more easily jump to each meeting in the doc.
-
-## Working Group Monthly
-
-✏️ See the [Group meeting notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.94vl69f1t8ph).
-
-🗓 Second Thursdays monthly at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/), unless otherwise specified.
-
-- June 10, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.v6mtcpwbglcp)
-- May 13, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.lq3s56hyydm0)
-- April 15, 2021: [recording](https://www.youtube.com/watch?v=c_GqwvP5Wqw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=5), [chat](meetings/monthly/2021-04-15-chat.txt)
-- March 11, 2021: [recording](https://www.youtube.com/watch?v=P5Ib1CubO54&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=4), [chat](meetings/monthly/2021-03-11-chat.txt)
-- February 11, 2021: [recording](https://www.youtube.com/watch?v=NilaC6Jhq_8&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=3), [chat](meetings/monthly/2021-02-11-chat.txt)
-- January 14, 2021: [recording](https://www.youtube.com/watch?v=JypiRn8HTbw&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=2), [chat](meetings/monthly/2021-01-14-chat.txt)
-- December 10, 2020: [recording](https://www.youtube.com/watch?v=LnzIE6tDfbQ&list=PLXOML2VBdIo4-biBmCbfNkP0ywF0f5mau&index=1), [chat](meetings/monthly/2020-12-10-chat.txt)
-
-## GitOps Principles Committee Meetings
-
-✏️ See the [Committee meeting notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.kr2ebmvnmiq7).
-
-🗓 Wednesdays weekly at [19:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/), unless otherwise specified.
-
-- May 19, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.hb979iyzq4qb)
-- May 12, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.i3p0vl1o0vv)
-- May 5, 2021: [recording](https://www.youtube.com/watch?v=PtxZHUJWtRk&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=5&ab_channel=CNCFGitOpsWorkingGroup), [chat](meetings/committee-principles/2021-05-05-chat.txt)
-- April 28, 2021: [recording](https://www.youtube.com/watch?v=Djr8M8kLTXg&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=5&ab_channel=CNCFGitOpsWorkingGroup), [chat](meetings/committee-principles/2021-04-28-chat.txt)
-- April 14, 2021: [recording](https://www.youtube.com/watch?v=zWxAZuHNGYM&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=3), [chat](meetings/committee-principles/2021-04-14-chat.txt)
-- April 05, 2021: [recording](https://www.youtube.com/watch?v=SGcSRTWnT3k&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=2), [chat](meetings/committee-principles/2021-04-05-chat.txt)
-- March 29, 2021: [recording](https://www.youtube.com/watch?v=2VpbWrKjDkQ&list=PLXOML2VBdIo6XfUTaIbanBN2fIDEyR25s&index=1), [chat](meetings/committee-principles/2021-03-29-chat.txt)
-
-## Events Committee Meetings
-
-✏️ See the [Committee meeting notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.qeurskf1lqn).
-
-🗓 Wednesdays weekly at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/), unless otherwise specified.
-
-- May 26, 2021: [join link and agenda](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit#heading=h.3tmx4zqkuj67)
-- May 14, 2021: Not recorded during GitOpsCon EU 2021 postmortem
-- April 29, 2021: Not recorded during speaker scheduling
-- April 27, 2021: Not recorded during speaker scheduling
-- April 22, 2021: Not recorded during CFP review
-- April 21, 2021: Not recorded during CFP review
-- April 20, 2021: [recording](https://www.youtube.com/watch?v=V0qelLe3Xrs&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=3&ab_channel=CNCFGitOpsWorkingGroup), [chat](meetings/committee-gitopscon/2021-04-20-chat.txt)
-- April 15, 2021: [recording](https://www.youtube.com/watch?v=lwX5MBS1mk8&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=2), [chat](meetings/committee-gitopscon/2021-04-15-chat.txt)
-- April 06, 2021: [recording](https://www.youtube.com/watch?v=qNplG7Rw-YU&list=PLXOML2VBdIo47l-Kr0LpZFNbZcL97tnex&index=1), [chat](meetings/committee-gitopscon/2021-04-06-chat.txt)
+- 🗓 Working Group meetings are currently every other Wednesday at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/)
+- 👩‍💻 Join using [this Zoom link](https://zoom.us/j/93779536510?pwd=TEFzbGRzREI3MVlkZmluemVkMEhHdz09)
+- ✏️ See [Agenda and Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for next and and all previous meetings
+(hint: use the [document outline](https://support.google.com/docs/answer/6367684) to help navigate!)
+- 📼 Browse WG [YouTube playlists](https://www.youtube.com/channel/UCI6iqYuuI4gZuOCZaks5i1g/playlists) for recordings of all previous meetings
+- 📧 Additional committee meetings may be scheduled as needed, and will be announced on the [CNCF App Delivery TAG](https://github.com/cncf/tag-app-delivery) mailing list, prefixed with `[gitops-wg]`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ This aims to give participants in the cloud native ecosystem a common understand
 4. **Software Agents**: Reconcilers maintain system state and apply the resources described in the declarative configuration.
 5. **Closed loop**: Actions are performed on divergence between the version controlled declarative configuration and the actual state of the target system.
 
+## Meetings
+
+- 🗓 Working Group meetings are currently every other Wednesday at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/)
+- 👩‍💻 Join using [this Zoom link](https://zoom.us/j/93779536510?pwd=TEFzbGRzREI3MVlkZmluemVkMEhHdz09)
+- ✏️ See [Agenda and Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for next and and all previous meetings
+(hint: use the [document outline](https://support.google.com/docs/answer/6367684) to help navigate!)
+- 📼 Browse WG [YouTube playlists](https://www.youtube.com/channel/UCI6iqYuuI4gZuOCZaks5i1g/playlists) for recordings of all previous meetings
+- 📧 Additional committee meetings may be scheduled as needed, and will be announced on the [CNCF App Delivery TAG](https://github.com/cncf/tag-app-delivery) mailing list, prefixed with `[gitops-wg]`
+
 ## How to Get Involved
 
 The GitOps Working Group is an open group, inviting companies and individuals to join and contribute to the community and the adoption of GitOps across the cloud native landscape.
@@ -51,14 +60,14 @@ There are a few ways you can get involved:
 
 - Watch or star this repo to see when things change
 - Join the [GitOps Subreddit](https://www.reddit.com/r/GitOps/)
-- Attend a [Working Group or Committee meeting](./MEETINGS.md)
+- Attend a [Working Group or Committee meeting](#meetings)
 - [Open an issue](/../../issues/new) and let us know how you're using GitOps and any important considerations we should include
 - Join `#wg-gitops` on [CNCF Slack](https://slack.cncf.io/)
 - Join the [SIG App Delivery](https://github.com/cncf/sig-app-delivery) mailing list, and watch or participate in topics prefixed with `[gitops-wg]`
 - See [Working Group project boards](https://github.com/orgs/gitops-working-group/projects) for status of work, or for ideas on areas that could use additional participation
 - Volunteer to join [committees](GOVERNANCE.md#committees) and help with projects according to your interest and ability
 
-The Working Group will review all open issues and PRs at our regular working group meeting (schedule coming soon).
+The Working Group will review all open issues and PRs at our [regular working group meeting](#meetings).
 
 ## Timeline
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,6 @@ This aims to give participants in the cloud native ecosystem a common understand
 4. **Software Agents**: Reconcilers maintain system state and apply the resources described in the declarative configuration.
 5. **Closed loop**: Actions are performed on divergence between the version controlled declarative configuration and the actual state of the target system.
 
-## Meetings
-
-- 🗓 Working Group meetings are currently every other Wednesday at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/)
-- 👩‍💻 Join using [this Zoom link](https://zoom.us/j/93779536510?pwd=TEFzbGRzREI3MVlkZmluemVkMEhHdz09)
-- ✏️ See [Agenda and Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for next and and all previous meetings
-(hint: use the [document outline](https://support.google.com/docs/answer/6367684) to help navigate!)
-- 📼 Browse WG [YouTube playlists](https://www.youtube.com/channel/UCI6iqYuuI4gZuOCZaks5i1g/playlists) for recordings of all previous meetings
-- 📧 Additional committee meetings may be scheduled as needed, and will be announced on the [CNCF App Delivery TAG](https://github.com/cncf/tag-app-delivery) mailing list, prefixed with `[gitops-wg]`
-
 ## How to Get Involved
 
 The GitOps Working Group is an open group, inviting companies and individuals to join and contribute to the community and the adoption of GitOps across the cloud native landscape.
@@ -68,6 +59,15 @@ There are a few ways you can get involved:
 - Volunteer to join [committees](GOVERNANCE.md#committees) and help with projects according to your interest and ability
 
 The Working Group will review all open issues and PRs at our [regular working group meeting](#meetings).
+
+## Meetings
+
+- 🗓 The WG now meets every other Wednesday at [18:00 GMT](https://greenwichmeantime.com/time-gadgets/time-zone-converter/)
+- 👩‍💻 Join using [this Zoom link](https://zoom.us/j/93779536510?pwd=TEFzbGRzREI3MVlkZmluemVkMEhHdz09)
+- ✏️ See [Agenda and Notes](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/) for next and and all previous meetings
+- 💡 Hint: use the [document outline](https://support.google.com/docs/answer/6367684) to help navigate to the right meeting!
+- 📼 Browse the [YouTube playlists](https://www.youtube.com/channel/UCI6iqYuuI4gZuOCZaks5i1g/playlists) for recordings of all previous meetings
+- 📧 Additional committee meetings may be scheduled as needed, and will be announced on the [CNCF App Delivery TAG](https://github.com/cncf/tag-app-delivery) mailing list, prefixed with `[gitops-wg]`
 
 ## Timeline
 


### PR DESCRIPTION
See:
- https://github.com/open-gitops/project/discussions/18#discussioncomment-1327866
- #70 

This PR accompanies changes to [notes and agenda doc](https://docs.google.com/document/d/1hxifmCdOV5_FbKloDJRWZQHq0ge-trXJKF-BgV4wHVk/edit?usp=sharing), which clarifies the [new fortnightly WG meeting cadence](https://github.com/open-gitops/project/discussions/18#discussioncomment-1327866).

