### PR TITLE
docs(interested-parties.md): Cornelia Davis

### DIFF
--- a/interested-parties.md
+++ b/interested-parties.md
@@ -4,6 +4,7 @@ Organization | Person
 -- | --
 Aivitex | Lothar Schulz
 Alibaba | Lei Zhang
+Amazon | Cornelia Davis
 AppCtl | Yuce Sungur
 Argo Project (individual) | Jann Fischer
 Atos | Sunil Sukumaran
@@ -90,7 +91,6 @@ Verifa | Jacob Larfors
 Vmware | Dmitriy Kalinin
 VMware | Garry Ing
 Weaveworks | Alexis Richardson
-Weaveworks | Cornelia Davis
 Weaveworks | Daniel Lizio-Katzen
 Weaveworks | Brice Fernandes
 Weaveworks | Scott Rigby


### PR DESCRIPTION
While @cdavisafc asked about the GitOpsCon schedule, this is related:
> Can someone please, please, please update the GitOpsCon schedule to correct my company affiliation. I've updated my sched profile, but the description of the panel still shows Weaveworks. Please update to Amazon.

URLs:
Slack https://cloud-native.slack.com/archives/C01R2GXGTDL/p1632623528041400
Sched https://kccncna2021.sched.com/speaker/cornelia10
OCT 12 ~~Weaveworks~~ Amazon https://gitopsconna21.sched.com/event/mzyQ
OCT 13 Amazon https://kccncna2021.sched.com/event/lV0t
JUN 22 Weaveworks https://gitopssummit2021.sched.com/event/il7Y/keynote-panel-why-gitops-tracy-ragan-deployhub-dan-garfield-codefresh-cornelia-davis-weaveworks-moderated-by-dan-lorenc-google